### PR TITLE
Only build docs on changes to docs folder

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,10 +3,14 @@ name: deploy-website
 # Only run this when the master branch changes
 on:
   push:
+    paths:
+    - docs/**
     branches:
     - master
 
   pull_request:
+    paths:
+    - docs/**
     branches:
     - master
 


### PR DESCRIPTION
I figure it makes sense to only build docs when the docs folder change. I assume there is no out of docs folder inspection though, which there may be, then we should not merge this. For example, a script that inspects content in the folder to /docs.