### PR TITLE
Change Ian Allison's email address on Callysto hub

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -37,14 +37,14 @@ hubs:
             users:
               - yuvipanda@gmail.com
               - colliand@gmail.com
-              - iana@pims.math.ca
+              - ifallison@gmail.com
               - byron.chu@cybera.ca
               - choldgraf@gmail.com
           admin:
             users:
               - yuvipanda@gmail.com
               - colliand@gmail.com
-              - iana@pims.math.ca
+              - ifallison@gmail.com
               - byron.chu@cybera.ca
               - choldgraf@gmail.com
   - name: wageningen


### PR DESCRIPTION
Jim Colliander made a mistake setting up Ian's account on Callysto. This PR should fix that.