### PR TITLE
el camino jupyterhub

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -72,9 +72,9 @@ hubs:
               - choldgraf
               - Chiil
   - name: ccsf
-    org_name: Community College SF
-    org_logo: https://www.wur.nl/upload/58340fb4-e33a-4d0b-af17-8d596fa93663_WUR_RGB_standard.png
-    org_url: https://www.wur.nl/en/wageningen-university.htm
+    org_name: City College SF
+    org_logo: https://www.ccsf.edu/sites/default/files/inline-images/asset-th-logo-black.png
+    org_url: https://www.ccsf.edu/
     domain: ccsf.pilot.2i2c.cloud
     auth0:
       connection: github
@@ -91,3 +91,25 @@ hubs:
             users:
               - choldgraf
               - ericvd-ucb
+              
+  - name: elcamino
+    org_name: El Camino College
+    org_logo: https://www.elcamino.edu/_resources/images/logo.png
+    org_url: https://www.elcamino.edu/
+    domain: elcamino.pilot.2i2c.cloud
+    auth0:
+      connection: github
+    config:
+      jupyterhub:
+        auth:
+          # Admin names need to be listed wtice here, unfortunately
+          # 'whitelist' will be removed by next jupyterhub release
+          whitelist:
+            users:
+              - choldgraf
+              - ericvd-ucb
+          admin:
+            users:
+              - choldgraf
+              - ericvd-ucb
+              


### PR DESCRIPTION
adds an el camino jupyterhub in anticipation of a future deployment so we can start playing around. also fixes the ccsf info