### PR TITLE
Remove jupyter-desktop-server

### DIFF
--- a/images/user/Dockerfile
+++ b/images/user/Dockerfile
@@ -130,5 +130,3 @@ RUN /tmp/install.R && \
 
 # Set bash as shell in terminado.
 ADD jupyter_notebook_config.py  ${CONDA_PREFIX}/etc/jupyter/
-# Disable history.
-ADD ipython_config.py ${CONDA_PREFIX}/etc/ipython/

--- a/images/user/environment.yml
+++ b/images/user/environment.yml
@@ -1,8 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-  # for jupyter-desktop-server
-  - websockify
 
   # language runtimes
   - python=3.8.*
@@ -37,7 +35,6 @@ dependencies:
     - jupytext==1.6.*
     - RISE==5.6.1
     - jupyter_contrib_nbextensions==0.5.1
-    - jupyter-desktop-server==0.1.3
     - notebook==6.1.4
     - jupyterhub==1.1.0
     - jupyter-server-proxy==1.5.0


### PR DESCRIPTION
This should remove jupyter-desktop-server in response to #73. If it's better to keep it and fix it please feel free to close this, I'm just trying to get familiar with the issue queue 😄 

When I build this locally I get

```
ADD failed: stat /var/lib/docker/tmp/docker-builder757307623/ipython_config.py: no such file or directory
```

Is that something I'm missing in the build process? I don't see `ipython_config.py` in images/user.