### PR TITLE
Put user pods on their own pools

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -28,6 +28,9 @@ jupyterhub:
       kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
   scheduling:
+    userPlaceholder:
+      enabled: true
+      replicas: 1
     podPriority:
       enabled: true
       globalDefault: false
@@ -86,6 +89,8 @@ jupyterhub:
         subPath: _shared
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
+    nodeSelector:
+      hub.jupyter.org/pool-name: user-pool
     image:
       name: set_automatically_by_automation
       tag: 6ebfc5d


### PR DESCRIPTION
We have been provisioning separate core and user pods,
but weren't forcing user pods on user pools. This has caused
resource exhaustion for core and support pods. With the minimum
user placeholder pods, we will always have at least one user
node running - increasing costs, but worth it for stability.

Fixes #89