### PR TITLE
Allow deploying all hubs or only one hub

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -57,7 +57,7 @@ def build():
             cluster.build_image()
 
 
-def deploy(cluster_name=None, hub_name=None):
+def deploy(cluster_name, hub_name):
     """
     Deploy all hubs in all clusters
     """
@@ -112,29 +112,15 @@ def main():
     build_parser = subparsers.add_parser('build')
     deploy_parser = subparsers.add_parser('deploy')
 
-    deploy_subparsers = deploy_parser.add_subparsers(dest='mode')
-
-    all_parser = deploy_subparsers.add_parser(
-        'all-hubs',
-        help='Deploy all the hubs'
-    )
-    hub_parser = deploy_subparsers.add_parser(
-        'hub',
-        help='Only deploy a specific hub in a cluster'
-    )
-
-    hub_parser.add_argument('cluster_name')
-    hub_parser.add_argument('hub_name')
+    deploy_parser.add_argument('cluster_name', nargs="?")
+    deploy_parser.add_argument('hub_name', nargs="?")
 
     args = argparser.parse_args()
 
     if args.action == 'build':
         build()
     elif args.action == 'deploy':
-        if args.mode == 'all-hubs':
-            deploy()
-        else:
-            deploy(args.cluster_name, args.hub_name)
+        deploy(args.cluster_name, args.hub_name)
 
 if __name__ == '__main__':
     main()

--- a/deploy.py
+++ b/deploy.py
@@ -29,24 +29,6 @@ def parse_clusters():
     ]
 
 
-def find_cluster(cluster_name, clusters):
-    """
-    Find a cluster by name in a list of Cluster objects
-    """
-    for cluster in clusters:
-        if cluster.spec['name'] == cluster_name:
-            return cluster
-
-
-def find_hub(hub_name, hubs):
-    """
-    Find a hub by name in a list of Hub objects
-    """
-    for hub in hubs:
-        if hub.spec['name'] == hub_name:
-            return hub
-
-
 def build():
     """
     Build and push all images for all clusters
@@ -89,11 +71,11 @@ def deploy(cluster_name, hub_name):
     clusters = parse_clusters()
 
     if cluster_name:
-        cluster = find_cluster(cluster_name, clusters)
+        cluster = next((cluster for cluster in clusters if cluster.spec['name'] == cluster_name), None)
         with cluster.auth():
             hubs = cluster.hubs
             if hub_name:
-                hub = find_hub(hub_name, hubs)
+                hub = next((hub for hub in hubs if hub.spec['name'] == hub_name), None)
                 hub.deploy(k, PROXY_SECRET_KEY)
             else:
                 for hub in hubs:

--- a/deploy.py
+++ b/deploy.py
@@ -29,7 +29,7 @@ def parse_clusters():
     ]
 
 
-def find_cluster_by_name(cluster_name, clusters):
+def find_cluster(cluster_name, clusters):
     """
     Find a cluster by name in a list of Cluster objects
     """
@@ -38,7 +38,7 @@ def find_cluster_by_name(cluster_name, clusters):
             return cluster
 
 
-def find_hub_in_cluster(hub_name, hubs):
+def find_hub(hub_name, hubs):
     """
     Find a hub by name in a list of Hub objects
     """
@@ -89,11 +89,11 @@ def deploy(cluster_name, hub_name):
     clusters = parse_clusters()
 
     if cluster_name:
-        cluster = find_cluster_by_name(cluster_name, clusters)
+        cluster = find_cluster(cluster_name, clusters)
         with cluster.auth():
             hubs = cluster.hubs
             if hub_name:
-                hub = find_hub_in_cluster(hub_name, hubs)
+                hub = find_hub(hub_name, hubs)
                 hub.deploy(k, PROXY_SECRET_KEY)
             else:
                 for hub in hubs:


### PR DESCRIPTION
I also kept the option to deploy all hubs to be able to be fast when needed.

```bash
deploy.py deploy all-hubs
or
deploy.py deploy hub <cluster-name> <hub-name>
```

But there might be a little too many parsers and subparsers :sweat_smile: Is this ok?

Closes https://github.com/2i2c-org/pilot-hubs/issues/110