### PR TITLE
Don't set OAUTH_CALLBACK_URL env var

### DIFF
--- a/hub.py
+++ b/hub.py
@@ -141,11 +141,6 @@ class Hub:
                         'name': self.cluster.spec['image_repo']
                     },
                 },
-                'hub': {
-                    'extraaEnv': {
-                        'OAUTH_CALLBACK_URL': f'https://{self.spec["domain"]}/hub/oauth_callback'
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
- A typo meant we never actually set this
- Things continue to work without it, so let's clear it out