### PR TITLE
Limit prometheus resource consumption

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -22,6 +22,14 @@ prometheus:
   rbac:
     create: true
   server:
+    resources:
+      # Without this, prometheus can easily starve users
+      requests:
+        cpu: 0.2
+        memory: 768Mi
+      limits:
+        cpu: 1
+        memory: 2Gi
     labels:
       # For HTTP access to the hub, to scrape metrics
       hub.jupyter.org/network-access-hub: 'true'


### PR DESCRIPTION
It's on the same nodes as the core pods, and if left to its
own devices it can take up all the resources on the nodes.

Ref #90