### PR TITLE
Grant SA permission to login to NFS Server

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,8 @@ module "service_accounts" {
   project_roles = [
     "${var.project_id}=>roles/container.admin",
     "${var.project_id}=>roles/artifactregistry.writer",
-    "${var.project_id}=>roles/compute.osAdminLogin"
+    # FIXME: This is way too much perms just to ssh into a node
+    "${var.project_id}=>roles/compute.instanceAdmin.v1"
   ]
 }
 


### PR DESCRIPTION
These permissions are too lax, should migrate to
using
https://cloud.google.com/compute/docs/instances/managing-instance-access
instead - at least.