### PR TITLE
Update base-hub and ephemeral-hub charts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Fetch helm charts
         run: |
-          helm dep up hub
+          helm dep up hub-templates/base-hub
+          helm dep up hub-templates/ephemeral-hub
 
       - name: Setup gcloud auth for docker
         # FIXME: Add more auth providers & registries here as needed

--- a/hub-templates/ephemeral-hub/Chart.yaml
+++ b/hub-templates/ephemeral-hub/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: '1.0'
-description: Deployment Chart for JupyterHub
+description: Deployment Chart for an ephemeral JupyterHub
 name: ephemeral-hub
 version: 0.0.1-n2724.h1dfae31
 baseHubPrefix: ephemeral-hub


### PR DESCRIPTION
In https://github.com/2i2c-org/pilot-hubs/pull/123, the hub has been separated into base-hub and ephemeral-hub templates.
Should fix the automatic deployment.