### PR TITLE
Add 'daskhub' template

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,7 @@ jobs:
         run: |
           helm dep up hub-templates/base-hub
           helm dep up hub-templates/ephemeral-hub
+          helm dep up hub-templates/daskhub
 
       - name: Setup gcloud auth for docker
         # FIXME: Add more auth providers & registries here as needed

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,9 +24,8 @@ jobs:
 
       - name: Fetch helm charts
         run: |
-          helm dep up hub-templates/base-hub
-          helm dep up hub-templates/ephemeral-hub
-          helm dep up hub-templates/daskhub
+          cd hub-templates
+          ls | xargs -L1 helm dep up
 
       - name: Setup gcloud auth for docker
         # FIXME: Add more auth providers & registries here as needed

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -38,6 +38,8 @@ jupyterhub:
       userPlaceholderPriority: -10
     userScheduler:
       enabled: true
+      nodeSelector:
+        hub.jupyter.org/pool-name: core-pool
       resources:
         requests:
           # FIXME: Just unset this?
@@ -54,6 +56,8 @@ jupyterhub:
     service:
       type: ClusterIP
     chp:
+      nodeSelector:
+        hub.jupyter.org/pool-name: core-pool
       resources:
         requests:
           # FIXME: We want no guarantees here!!!
@@ -63,6 +67,8 @@ jupyterhub:
         limits:
           memory: 1Gi
     traefik:
+      nodeSelector:
+        hub.jupyter.org/pool-name: core-pool
       resources:
         requests:
           memory: 64Mi
@@ -128,6 +134,8 @@ jupyterhub:
   auth:
     type: dummy
   hub:
+    nodeSelector:
+      hub.jupyter.org/pool-name: core-pool
     networkPolicy:
       enabled: true
       ingress:

--- a/hub-templates/daskhub/.helmignore
+++ b/hub-templates/daskhub/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/hub-templates/daskhub/Chart.lock
+++ b/hub-templates/daskhub/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: base-hub
+  repository: file://../base-hub
+  version: 0.0.1
+- name: dask-gateway
+  repository: https://dask.org/dask-gateway-helm-repo/
+  version: 0.9.0
+digest: sha256:de2e3d8c0e278fef2d15c3a583422c6f148e290b7133ba00c5ba259ce4b48c0d
+generated: "2020-12-09T16:30:33.83066+05:30"

--- a/hub-templates/daskhub/Chart.yaml
+++ b/hub-templates/daskhub/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: '1.0'
+description: Deployment Chart for an ephemeral JupyterHub
+name: ephemeral-hub
+version: 0.0.1-n2724.h1dfae31
+dependencies:
+ - name: base-hub
+   version: 0.0.1
+   repository: file://../base-hub
+ - name: dask-gateway
+   version: "0.9.0"
+   repository: 'https://dask.org/dask-gateway-helm-repo/'

--- a/hub-templates/daskhub/Chart.yaml
+++ b/hub-templates/daskhub/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: '1.0'
-description: Deployment Chart for an ephemeral JupyterHub
-name: ephemeral-hub
+description: Deployment Chart for a dask-enabled JupyterHub
+name: daskhub
 version: 0.0.1-n2724.h1dfae31
 dependencies:
  - name: base-hub

--- a/hub-templates/daskhub/requirements.lock
+++ b/hub-templates/daskhub/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: base-hub
+  repository: file://../base-hub
+  version: v0.0.1
+digest: sha256:6ca4e6932a628f86794cf70bacb9a159a26aee474202336f73841855d9449f15
+generated: "2020-12-04T09:50:53.935463+05:30"

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -1,0 +1,156 @@
+base-hub:
+  # Copied from https://github.com/dask/helm-chart/blob/master/daskhub/values.yaml
+  # FIXME: Properly use the upstream chart.
+  jupyterhub:
+    prePuller:
+      hook:
+        enabled: false
+    singleuser:
+      extraLabels:
+         hub.jupyter.org/network-access-proxy-http: "true"
+
+      networkPolicy:
+        # Needed for talking to the proxy pod
+        egress:
+          - ports:
+              - port: 8000
+                protocol: TCP
+          - ports:
+              - port: 80
+                protocol: TCP
+          - ports:
+              - port: 443
+                protocol: TCP
+      cloudMetadata:
+        enabled: true
+        # Don't block access to AWS cloud metadata
+        # If we don't, our users can't access S3 buckets / other AWS services
+        # without an explicit identity
+        # FIXME: Provide an explicit identity for users instead
+        blockWithIptables: false
+      extraEnv:
+        # The default worker image matches the singleuser image.
+        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+    hub:
+      networkPolicy:
+        enabled: false
+      extraConfig:
+        daskhub-01-add-dask-gateway-values: |
+          # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.
+          # 2. Adds the URL for the Dask Gateway JupyterHub service.
+          import os
+          # These are set by jupyterhub.
+          release_name = os.environ["HELM_RELEASE_NAME"]
+          release_namespace = os.environ["POD_NAMESPACE"]
+          if "PROXY_HTTP_SERVICE_HOST" in os.environ:
+              # https is enabled, we want to use the internal http service.
+              gateway_address = "http://{}:{}/services/dask-gateway/".format(
+                  os.environ["PROXY_HTTP_SERVICE_HOST"],
+                  os.environ["PROXY_HTTP_SERVICE_PORT"],
+              )
+              print("Setting DASK_GATEWAY__ADDRESS {} from HTTP service".format(gateway_address))
+          else:
+              gateway_address = "http://proxy-public/services/dask-gateway"
+              print("Setting DASK_GATEWAY__ADDRESS {}".format(gateway_address))
+          # Internal address to connect to the Dask Gateway.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__ADDRESS", gateway_address)
+          # Internal address for the Dask Gateway proxy.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__PROXY_ADDRESS", "gateway://traefik-{}-dask-gateway.{}:80".format(release_name, release_namespace))
+          # Relative address for the dashboard link.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__PUBLIC_ADDRESS", "/services/dask-gateway/")
+          # Use JupyterHub to authenticate with Dask Gateway.
+          c.KubeSpawner.environment.setdefault("DASK_GATEWAY__AUTH__TYPE", "jupyterhub")
+          # Adds Dask Gateway as a JupyterHub service to make the gateway available at
+          # {HUB_URL}/services/dask-gateway
+          service_url = "http://traefik-{}-dask-gateway.{}".format(release_name, release_namespace)
+          for service in c.JupyterHub.services:
+              if service["name"] == "dask-gateway":
+                  if not service.get("url", None):
+                      print("Adding dask-gateway service URL")
+                      service.setdefault("url", service_url)
+                  break
+          else:
+              print("dask-gateway service not found. Did you set jupyterhub.hub.services.dask-gateway.apiToken?")
+
+dask-gateway:
+  enabled: true  # Enabling dask-gateway will install Dask Gateway as a dependency.
+  # Futher Dask Gateway configuration goes here
+  # See https://github.com/dask/dask-gateway/blob/master/resources/helm/dask-gateway/values.yaml
+  gateway:
+    backend:
+      scheduler:
+        cores:
+          request: 0.01
+          limit: 1
+        memory:
+          request: 128M
+          limit: 1G
+        extraPodConfig:
+          tolerations:
+            - key: "k8s.dask.org/dedicated"
+              operator: "Equal"
+              value: "scheduler"
+              effect: "NoSchedule"
+            - key: "k8s.dask.org_dedicated"
+              operator: "Equal"
+              value: "scheduler"
+              effect: "NoSchedule"
+      worker:
+        extraContainerConfig:
+          securityContext:
+            runAsGroup: 1000
+            runAsUser: 1000
+        extraPodConfig:
+          securityContext:
+            fsGroup: 1000
+          tolerations:
+            - key: "dask-dedicated"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+
+    # TODO: figure out a replacement for userLimits.
+    extraConfig:
+      optionHandler: |
+        from dask_gateway_server.options import Options, Integer, Float, String
+
+        def cluster_options(user):
+            def option_handler(options):
+                if ":" not in options.image:
+                    raise ValueError("When specifying an image you must also provide a tag")
+                # FIXME: No user labels or annotations, until https://github.com/pangeo-data/pangeo-cloud-federation/issues/879
+                # is fixed.
+                extra_annotations = {
+                    # "hub.jupyter.org/username": safe_username,
+                    "prometheus.io/scrape": "true",
+                    "prometheus.io/port": "8787",
+                }
+                extra_labels = {
+                    # "hub.jupyter.org/username": safe_username,
+                }
+                return {
+                    "worker_cores_limit": options.worker_cores,
+                    "worker_cores": min(options.worker_cores / 2, 1),
+                    "worker_memory": "%fG" % options.worker_memory,
+                    "image": options.image,
+                    "scheduler_extra_pod_annotations": extra_annotations,
+                    "worker_extra_pod_annotations": extra_annotations,
+                    "scheduler_extra_pod_labels": extra_labels,
+                    "worker_extra_pod_labels": extra_labels,
+                }
+            return Options(
+                Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
+                Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
+                String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+                handler=option_handler,
+            )
+        c.Backend.cluster_options = cluster_options
+      idle: |
+        # timeout after 30 minutes of inactivity
+        c.KubeClusterConfig.idle_timeout = 1800
+    prefix: "/services/dask-gateway"  # Users connect to the Gateway through the JupyterHub service.
+    auth:
+      type: jupyterhub  # Use JupyterHub to authenticate with Dask Gateway
+  traefik:
+    service:
+      type: ClusterIP  # Access Dask Gateway through JupyterHub. To access the Gateway from outside JupyterHub, this must be changed to a `LoadBalancer`.

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -86,15 +86,9 @@ dask-gateway:
           request: 128M
           limit: 1G
         extraPodConfig:
-          tolerations:
-            - key: "k8s.dask.org/dedicated"
-              operator: "Equal"
-              value: "scheduler"
-              effect: "NoSchedule"
-            - key: "k8s.dask.org_dedicated"
-              operator: "Equal"
-              value: "scheduler"
-              effect: "NoSchedule"
+          nodeSelector:
+            # Schedulers should be in the user pool
+            hub.jupyter.org/pool-name: user-pool
       worker:
         extraContainerConfig:
           securityContext:
@@ -103,11 +97,9 @@ dask-gateway:
         extraPodConfig:
           securityContext:
             fsGroup: 1000
-          tolerations:
-            - key: "dask-dedicated"
-              operator: "Equal"
-              value: "worker"
-              effect: "NoSchedule"
+          nodeSelector:
+            # Dask workers get their own pre-emptible pool
+            hub.jupyter.org/pool-name: dask-worker-pool
 
     # TODO: figure out a replacement for userLimits.
     extraConfig:

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -21,6 +21,10 @@ base-hub:
           - ports:
               - port: 443
                 protocol: TCP
+          # Enable outgoing ssh by default on these hubs
+          - ports:
+              - port: 22
+                protocol: TCP
       cloudMetadata:
         enabled: true
         # Don't block access to AWS cloud metadata

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -76,7 +76,12 @@ dask-gateway:
   enabled: true  # Enabling dask-gateway will install Dask Gateway as a dependency.
   # Futher Dask Gateway configuration goes here
   # See https://github.com/dask/dask-gateway/blob/master/resources/helm/dask-gateway/values.yaml
+  controller:
+    nodeSelector:
+      hub.jupyter.org/pool-name: core-pool
   gateway:
+    nodeSelector:
+      hub.jupyter.org/pool-name: core-pool
     backend:
       scheduler:
         cores:
@@ -144,5 +149,7 @@ dask-gateway:
     auth:
       type: jupyterhub  # Use JupyterHub to authenticate with Dask Gateway
   traefik:
+    nodeSelector:
+      hub.jupyter.org/pool-name: core-pool
     service:
       type: ClusterIP  # Access Dask Gateway through JupyterHub. To access the Gateway from outside JupyterHub, this must be changed to a `LoadBalancer`.

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -292,65 +292,66 @@ clusters:
       - name: catalyst-cooperative
         cluster: pilot
         domain: catalyst-cooperative.pilot.2i2c.cloud
-        template: base-hub
+        template: daskhub
         auth0:
           connection: google-oauth2
         config:
-          jupyterhub:
-            singleuser:
-              memory:
-                limit: 6G
-                guarantee: 4G
-              networkPolicy:
-                # We want to enable outgoing ssh just for this hub, so we do that here.
-                # We can't *just* add port 22 here, since egress is a list not a dictionary
-                egress:
-                  - ports:
-                      - port: 53
-                        protocol: UDP
-                  - ports:
-                      - port: 80
-                        protocol: TCP
-                  - ports:
-                      - port: 443
-                        protocol: TCP
-                  - ports:
-                      - port: 22
-                        protocol: TCP
-            homepage:
-              templateVars:
-                org:
-                  name: Catalyst Cooperative
-                  logo_url: https://catalyst.coop/files/2018/06/SimpleSquareWalking.png
-                  url: https://catalyst.coop/
-                designed_by:
-                  name: 2i2c
-                  url: https://2i2c.org
-                operated_by:
-                  name: CloudBank
-                  url: http://cloudbank.org/
-                funded_by:
-                  name: CloudBank
-                  url: http://cloudbank.org/
-            auth:
-              # Admin names need to be listed wtice here, unfortunately
-              # 'whitelist' will be removed by next jupyterhub release
-              whitelist:
-                users:
-                  - choldgraf@gmail.com
-                  - yuvipanda@gmail.com
-                  - georgiana.dolocan@gmail.com
-                  - zane.selvans@catalyst.coop
-                  - cgosnell@catalyst.coop
-                  - colliand@gmail.com
-              admin:
-                users:
-                  - choldgraf@gmail.com
-                  - yuvipanda@gmail.com
-                  - georgiana.dolocan@gmail.com
-                  - zane.selvans@catalyst.coop
-                  - cgosnell@catalyst.coop
-                  - colliand@gmail.com
+          base-hub:
+            jupyterhub:
+              singleuser:
+                memory:
+                  limit: 6G
+                  guarantee: 4G
+                networkPolicy:
+                  # We want to enable outgoing ssh just for this hub, so we do that here.
+                  # We can't *just* add port 22 here, since egress is a list not a dictionary
+                  egress:
+                    - ports:
+                        - port: 53
+                          protocol: UDP
+                    - ports:
+                        - port: 80
+                          protocol: TCP
+                    - ports:
+                        - port: 443
+                          protocol: TCP
+                    - ports:
+                        - port: 22
+                          protocol: TCP
+              homepage:
+                templateVars:
+                  org:
+                    name: Catalyst Cooperative
+                    logo_url: https://catalyst.coop/files/2018/06/SimpleSquareWalking.png
+                    url: https://catalyst.coop/
+                  designed_by:
+                    name: 2i2c
+                    url: https://2i2c.org
+                  operated_by:
+                    name: CloudBank
+                    url: http://cloudbank.org/
+                  funded_by:
+                    name: CloudBank
+                    url: http://cloudbank.org/
+              auth:
+                # Admin names need to be listed wtice here, unfortunately
+                # 'whitelist' will be removed by next jupyterhub release
+                whitelist:
+                  users:
+                    - choldgraf@gmail.com
+                    - yuvipanda@gmail.com
+                    - georgiana.dolocan@gmail.com
+                    - zane.selvans@catalyst.coop
+                    - cgosnell@catalyst.coop
+                    - colliand@gmail.com
+                admin:
+                  users:
+                    - choldgraf@gmail.com
+                    - yuvipanda@gmail.com
+                    - georgiana.dolocan@gmail.com
+                    - zane.selvans@catalyst.coop
+                    - cgosnell@catalyst.coop
+                    - colliand@gmail.com
       - name: earthlab
         cluster: 2i2c
         domain: earthlab.pilot.2i2c.cloud

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -305,22 +305,6 @@ clusters:
                 memory:
                   limit: 6G
                   guarantee: 4G
-                networkPolicy:
-                  # We want to enable outgoing ssh just for this hub, so we do that here.
-                  # We can't *just* add port 22 here, since egress is a list not a dictionary
-                  egress:
-                    - ports:
-                        - port: 53
-                          protocol: UDP
-                    - ports:
-                        - port: 80
-                          protocol: TCP
-                    - ports:
-                        - port: 443
-                          protocol: TCP
-                    - ports:
-                        - port: 22
-                          protocol: TCP
               homepage:
                 templateVars:
                   org:

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -11,6 +11,49 @@ clusters:
         server: nfs-server-01
         zone: us-central1-b
     hubs:
+      - name: dask-staging
+        cluster: 2i2c
+        domain: dask-staging.pilot.2i2c.cloud
+        template: daskhub
+        auth0:
+          connection: google-oauth2
+        config:
+          base-hub:
+            jupyterhub:
+              homepage:
+                templateVars:
+                  org:
+                    name: 2i2c Dask Staging
+                    url: https://2i2c.org
+                    logo_url: https://2i2c.org/media/logo.png
+                  designed_by:
+                    name: 2i2c
+                    url: https://2i2c.org
+                  operated_by:
+                    name: 2i2c
+                    url: https://2i2c.org
+                  funded_by:
+                    name: 2i2c
+                    url: https://2i2c.org
+              singleuser:
+                image:
+                  name: pangeo/pangeo-notebook
+                  tag: 2020.12.08
+              auth:
+                # Admin names need to be listed wtice here, unfortunately
+                # 'whitelist' will be removed by next jupyterhub release
+                whitelist:
+                  users:
+                    - yuvipanda@gmail.com
+                    - colliand@gmail.com
+                    - choldgraf@gmail.com
+                    - georgiana.dolocan@gmail.com
+                admin:
+                  users:
+                    - yuvipanda@gmail.com
+                    - colliand@gmail.com
+                    - choldgraf@gmail.com
+                    - georgiana.dolocan@gmail.com
       - name: ephemeral
         cluster: 2i2c
         domain: ephemeral.pilot.2i2c.cloud

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -299,6 +299,9 @@ clusters:
           base-hub:
             jupyterhub:
               singleuser:
+                image:
+                  name: pangeo/pangeo-notebook
+                  tag: 2020.12.08
                 memory:
                   limit: 6G
                   guarantee: 4G

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,6 +70,8 @@ module "gke" {
       auto_upgrade       = false
       preemptible        = false
       initial_node_count = 1
+      # Let's pin this so we don't upgrade each time terraform runs
+      version            = "1.17.12-gke.2502"
     },
     {
       name               = "user-pool-2020-09-29"
@@ -84,6 +86,26 @@ module "gke" {
       auto_upgrade       = false
       preemptible        = false
       initial_node_count = 0
+      # Let's pin this so we don't upgrade each time terraform runs
+      version            = "1.17.12-gke.2502"
+    },
+    {
+      name               = "dask-worker-pool-2020-12-11"
+      machine_type       = "e2-standard-4"
+      min_count          = 0
+      max_count          = 10
+      local_ssd_count    = 0
+      disk_size_gb       = 100
+      # Fast startup is important here, so we get fast SSD disks
+      # This pulls in user images much faster
+      disk_type          = "pd-ssd"
+      image_type         = "UBUNTU"
+      auto_repair        = true
+      auto_upgrade       = false
+      preemptible        = true
+      initial_node_count = 0
+      # Let's pin this so we don't upgrade each time terraform runs
+      version            = "1.17.12-gke.2502"
     },
   ]
 
@@ -104,6 +126,9 @@ module "gke" {
     }
     user-pool-2020-09-29 = {
       "hub.jupyter.org/pool-name" = "user-pool"
+    }
+    dask-worker-pool-2020-12-11 = {
+      "hub.jupyter.org/pool-name" = "dask-worker-pool"
     }
   }
 }


### PR DESCRIPTION
- Allows deploying new dask-enabled hubs with `hubs.yaml`
  workflow!
- Installs dask-gateway alongside our basic hub. We're using
  the 'dask-gateway' chart, but should move to the 'daskhub'
  chart instead at some point soon.
- Adds a 'dask-staging.pilot.2i2c.cloud' hub that has dask
  enabled!
- Defaults to a pangeo image, since we don't want to be curating
  these images ourselves.
- Factors out a function for making changes to the generated
  config. This is terrible and should be fixed.
- Put dask workers on preemptible nodes, since they
  should be resilient to lost workers
- Use e2 nodes instead of n1 nodes, since they are
  cheaper when the sustained use discount isn't applied
- Pin node versions in terraform, so it doesn't try to
  upgrade them each time we run terraform apply!
- Make catalyst coop a dask hub.
- Enable outgoing ssh for all daskhubs, since they are more
  likely to be research-oriented & need ssh push.

Ref #114