### PR TITLE
Add dask to our custom image

### DIFF
--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -101,7 +101,7 @@ jupyterhub:
       hub.jupyter.org/pool-name: user-pool
     image:
       name: set_automatically_by_automation
-      tag: f456273
+      tag: 4066a62
     storage:
       type: static
       static:

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -299,9 +299,6 @@ clusters:
           base-hub:
             jupyterhub:
               singleuser:
-                image:
-                  name: pangeo/pangeo-notebook
-                  tag: 2020.12.08
                 memory:
                   limit: 6G
                   guarantee: 4G

--- a/images/user/environment.yml
+++ b/images/user/environment.yml
@@ -23,6 +23,9 @@ dependencies:
   - astropy
   - galpy
   - catalystcoop.pudl
+  - dask==2020.12.0
+  - distributed==2020.12.0
+  - dask-gateway==0.9.0
 
   - pip
 


### PR DESCRIPTION
Issue #143 was caused by changing the catalyst coop image
to the pangeo image, to support dask. However, that doesn't
have nbresuse nor jupyter-resource-usage. Upstream,
https://github.com/pangeo-data/pangeo-docker-images/pull/173 is
working on fixing this.

Catalyst Coop isn't really using dask much, and doesn't need
most of the base libraries that pangeo images provides. So we
add dask to our base image, and use that instead.

Fixes #143