### PR TITLE
Use lowercase for hub name to fix helm release name

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -632,7 +632,7 @@ clusters:
                   - ericvd@gmail.com
                   - jp@jamespercy.com
                   - colliand@gmail.com
-      - name: Lassen
+      - name: lassen
         cluster: cloudbank
         domain: lassen.cloudbank.2i2c.cloud
         template: base-hub


### PR DESCRIPTION
Can a helm release name start with an upper case?

Deploy is failing for the newly added Lassen hub with:

```
Error: release name is invalid: Lassen
```