### PR TITLE
Custom image for Catalyst Cooperative pilot hub

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -327,6 +327,9 @@ clusters:
           base-hub:
             jupyterhub:
               singleuser:
+                image:
+                  name: catalystcoop/pilot-hub
+                  tag: 2021.01.22
                 memory:
                   limit: 6G
                   guarantee: 4G


### PR DESCRIPTION
I've created an image using repo2docker based on [our tutorial repo](https://github.com/catalyst-cooperative/pudl-tutorials) and pushed it to docker hub [catalystcoop/pilot-hub:2021.01.22](https://hub.docker.com/r/catalystcoop/pilot-hub/tags?page=1&ordering=last_updated)  I think this PR would specify the use of that image for the catalyst hub's user environment. Right?

It seems to work with PUDL when I run it locally using `repo2docker` though I have not been able to run the image directly using `docker run` -- I haven't figured out how to get it to publish the right ports I don't think... it always comes up on `127.0.0.1:8888` but when I go to that address it won't load. Are there other things I can do to test it out before the hub switches over? It would be nice if I could set up local `shared` and `shared-readwrite` volumes to mount so I can test the tutorial notebooks locally as well. Not yet clear on how to mount external files into the image though.

Is it better to use a versioned tag like this (e.g. the date) and then have to make a PR every time we want to change the image? Or should I use something like `latest` so that the environment updates whenever I push a new version?