### PR TITLE
[WIP] Restrict access to a certain domain automatically

### DIFF
--- a/hub.py
+++ b/hub.py
@@ -241,11 +241,13 @@ class Hub:
             )
             generated_config['jupyterhub']['auth'] = auth_provider.get_client_creds(client, self.spec['auth0']['connection'])
 
-        # if self.spec["jupyterhub"]["auth"]["allowed_domains"]
-        r = auth_provider.create_google_domain_rule()
-        print("aaaaaaaaaaaaaaaaaaaaaaaaa")
-        print(r)
-
+        # If a domain is provided, make sure there is an auth0 rule that filters on this domain.
+        if self.spec['config']['jupyterhub']['auth']['allowed_domains']:
+            auth_provider.create_google_domain_rule(
+                self.spec['name'],
+                self.spec['config']['jupyterhub']['auth']['allowed_domains'],
+                self.spec['config']['jupyterhub']['auth']['admin']['users']
+            )
         return self.apply_hub_template_fixes(generated_config, proxy_secret_key)
 
 
@@ -392,7 +394,7 @@ class Hub:
             ]
 
             print(f"Running {' '.join(cmd)}")
-            # subprocess.check_call(cmd)
+            subprocess.check_call(cmd)
 
             if not skip_hub_health_test:
 

--- a/hub.py
+++ b/hub.py
@@ -241,6 +241,11 @@ class Hub:
             )
             generated_config['jupyterhub']['auth'] = auth_provider.get_client_creds(client, self.spec['auth0']['connection'])
 
+        # if self.spec["jupyterhub"]["auth"]["allowed_domains"]
+        r = auth_provider.create_google_domain_rule()
+        print("aaaaaaaaaaaaaaaaaaaaaaaaa")
+        print(r)
+
         return self.apply_hub_template_fixes(generated_config, proxy_secret_key)
 
 
@@ -387,7 +392,7 @@ class Hub:
             ]
 
             print(f"Running {' '.join(cmd)}")
-            subprocess.check_call(cmd)
+            # subprocess.check_call(cmd)
 
             if not skip_hub_health_test:
 

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -824,6 +824,8 @@ clusters:
                   name: CloudBank
                   url: http://cloudbank.org/
             auth:
+              allowed_domains:
+                - hello
               admin:
                 users:
                   - yuvipanda@2i2c.org

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -825,7 +825,7 @@ clusters:
                   url: http://cloudbank.org/
             auth:
               allowed_domains:
-                - hello
+                - mills.edu
               admin:
                 users:
                   - yuvipanda@2i2c.org


### PR DESCRIPTION
This should be smarter and instead of creating a new rule rule for each hub that has restriction based on domain in place, we should update an existing rule with the name of the hub.

Having lots of rules is bad also because the rules evaluate one after another in the order specified by their `order` field.