### PR TITLE
Move docs-service config outside hub config

### DIFF
--- a/hub-templates/base-hub/templates/docs-service-config.yaml
+++ b/hub-templates/base-hub/templates/docs-service-config.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.jupyterhub.docs_service.enabled }}
+{{ if .Values.docs_service.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/hub-templates/base-hub/templates/docs-service-deployment.yaml
+++ b/hub-templates/base-hub/templates/docs-service-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.jupyterhub.docs_service.enabled }}
+{{ if .Values.docs_service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,10 +26,10 @@ spec:
             - clone
             - --depth=1
             - -b
-            - {{ .Values.jupyterhub.docs_service.branch }}
+            - {{ .Values.docs_service.branch }}
             - --single-branch
             - --
-            - {{ .Values.jupyterhub.docs_service.repo }}
+            - {{ .Values.docs_service.repo }}
             - /srv/docs
           securityContext:
               runAsUser: 1000

--- a/hub-templates/base-hub/templates/nginx-docs-service.yaml
+++ b/hub-templates/base-hub/templates/nginx-docs-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.jupyterhub.docs_service.enabled }}
+{{ if .Values.docs_service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/hub.py
+++ b/hub.py
@@ -338,9 +338,10 @@ class Hub:
 
         }
 
-        generated_config['jupyterhub']['hub']['services']['docs'] = {
-            'url': f'http://docs-service.{self.spec["name"]}'
-        }
+        if 'docs_service' in self.spec['config'].keys() and self.spec['config']['docs_service']['enabled']:
+            generated_config['jupyterhub']['hub']['services']['docs'] = {
+                'url': f'http://docs-service.{self.spec["name"]}'
+            }
 
 
         # FIXME: Have a templates config somewhere? Maybe in Chart.yaml

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -18,11 +18,11 @@ clusters:
         auth0:
           connection: google-oauth2
         config:
+          docs_service:
+            enabled: true
+            repo: https://github.com/2i2c-org/pilot-hubs.git
+            branch: gh-pages
           jupyterhub:
-            docs_service:
-              enabled: true
-              repo: https://github.com/2i2c-org/pilot-hubs.git
-              branch: gh-pages
             homepage:
               templateVars:
                 org:


### PR DESCRIPTION
This should fix the [failing deployment](https://github.com/2i2c-org/pilot-hubs/runs/1786190208) after the docs-service addition. The failure was because the various templates the hubs use.

This PR moves the `docs-service` config outside of the `jupyterhub` config in `hubs.yaml`. The other available option to fix this would have been adding extra checks in all the `yaml` files that are conditioned by this service existence. 
I'm not sure this would have been the better choice, but since we could potentially change the current template hierarchy as we add other templates, maybe not.