### PR TITLE
Update Catalyst Cooperative Docker image

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -333,7 +333,7 @@ clusters:
               singleuser:
                 image:
                   name: catalystcoop/pilot-hub
-                  tag: 2021.01.22
+                  tag: 2021.02.03
                 memory:
                   limit: 6G
                   guarantee: 4G


### PR DESCRIPTION
Added `nbgitpuller` back into the environment (whoops!) as well as a `pip` dependency for `jupyter-offlinenotebook` since it was complaining about needing to be included in the build. Got automatic builds of the Docker image working from our examples repository using the `jupyter/repo2docker-action` GitHub action, with automatic date tagging.