### PR TITLE
Bump jhub_client

### DIFF
--- a/hub.py
+++ b/hub.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 from build import last_modified_commit
 from contextlib import contextmanager
 from build import build_image
-from jupyterhub_client.execute import execute_notebook, JupyterHubAPI
+from jhub_client.execute import execute_notebook, JupyterHubAPI
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ='safe', pure=True)
@@ -302,7 +302,7 @@ class Hub:
         hub_url = f'https://{self.spec["domain"]}'
         username='deployment-service-check'
 
-        # Export the hub health check service as an env var so that jupyterhub_client can read it.
+        # Export the hub health check service as an env var so that jhub_client can read it.
         orig_service_token = os.environ.get('JUPYTERHUB_API_TOKEN', None)
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 backoff
 ruamel.yaml
 auth0-python
-git+https://github.com/GeorgianaElena/jupyterhub_client.git@678d4733482b1196fcff3c05bd1fdb134777a475
+git+https://github.com/GeorgianaElena/jupyterhub_client.git@7aa8e4c8ee2da9b4d98065e9b19b766ab8f66be8


### PR DESCRIPTION
`jupyterhub_client` has been moved under the *Quansight* org and a few changes have been made to the repo structure.