### PR TITLE
Username pattern for mills

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -109,7 +109,7 @@ class KeyProvider:
             'username_key': username_key,
             'client_id': client['client_id'],
             'client_secret': client['client_secret'],
-            'scopes': ['openid', 'name', 'profile', 'email']
+            'scope': ['openid', 'name', 'profile', 'email']
         }
 
         return auth

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -709,4 +709,4 @@ clusters:
                     - georgiana.dolocan@gmail.com
                     - aculich@berkeley.edu
                     - jpercy@berkeley.edu
-                  username_pattern: '^.+@2i2c.org$|yuvipanda@gmail.com|choldgraf@gmail.com|georgiana.dolocan@gmail.com|aculich@berkeley.edu|jpercy@berkeley.edu|deployment-service-check'
+                  username_pattern: '^.+@mills.edu$|yuvipanda@gmail.com|choldgraf@gmail.com|georgiana.dolocan@gmail.com|aculich@berkeley.edu|jpercy@berkeley.edu|deployment-service-check'

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -709,4 +709,4 @@ clusters:
                     - georgiana.dolocan@gmail.com
                     - aculich@berkeley.edu
                     - jpercy@berkeley.edu
-                  username_pattern: '^.+@mills.edu$|yuvipanda@gmail.com|choldgraf@gmail.com|georgiana.dolocan@gmail.com|aculich@berkeley.edu|jpercy@berkeley.edu|deployment-service-check'
+                  username_pattern: '^(.+@mills\.edu|yuvipanda@gmail\.com|choldgraf@gmail\.com|georgiana\.dolocan@gmail\.com|aculich@berkeley\.edu|jpercy@berkeley\.edu|deployment-service-check)$'

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -703,11 +703,10 @@ clusters:
             hub:
               config:
                 Authenticator:
-                  admin_users:
-                    - yuvipanda@2i2c.org
+                  admin_users: &mills_admins
                     - yuvipanda@gmail.com
-                    - choldgraf@2i2c.org
-                    - georgianaelena@2i2c.org
+                    - choldgraf@gmail.com
                     - georgiana.dolocan@gmail.com
                     - aculich@berkeley.edu
                     - jpercy@berkeley.edu
+                  username_pattern: '^.+@2i2c.org$|yuvipanda@gmail.com|choldgraf@gmail.com|georgiana.dolocan@gmail.com|aculich@berkeley.edu|jpercy@berkeley.edu|deployment-service-check'


### PR DESCRIPTION
Didn't know how to make this smarter and don't copy the admins again in the regex, since the admin users have to comply with the `username_pattern` too :(

I have tried:
* Adding the admins in `hub.py` but `hubs.yaml` takes precedence over `generated_config`
* Some functions from here https://helm.sh/docs/chart_template_guide/function_list/ but didn't work and have no idea how to use them or they should work with this at all
