### PR TITLE
Use jh-client official pkg instead of the fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 backoff
 ruamel.yaml
 auth0-python
-git+https://github.com/GeorgianaElena/jupyterhub_client.git@7aa8e4c8ee2da9b4d98065e9b19b766ab8f66be8
+jhub-client==0.1.2


### PR DESCRIPTION
The latest version of `jh-client` now has all the changes we need :tada: There is no need in using the forked version anymore.