### PR TITLE
Give paleohack its own image

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -234,6 +234,10 @@ clusters:
                 funded_by:
                   name: "[TBD]"
                   url: https://example.com
+            singleuser:
+              image:
+                name: quay.io/2i2c/paleohack-2021
+                tag: 2c7ff948c272
             hub:
               config:
                 Authenticator:


### PR DESCRIPTION
See https://github.com/2i2c-org/leads/issues/1

Image is coming from https://github.com/LinkedEarth/paleoHackathon. See
https://github.com/LinkedEarth/paleoHackathon/pull/2 for autobuild status