### PR TITLE
Revert "Temporary disable nfs share setup until https://github.com/2i2c-org/p…"

### DIFF
--- a/hub.py
+++ b/hub.py
@@ -413,8 +413,7 @@ class Hub:
         generated_values = self.get_generated_config(auth_provider, proxy_secret_key)
 
         # FIXME: Don't do this for ephemeral hubs
-        # Temporary disable this until https://github.com/2i2c-org/pilot-hubs/issues/206 is fixed
-        # self.setup_nfs_share()
+        self.setup_nfs_share()
 
         with tempfile.NamedTemporaryFile() as values_file, tempfile.NamedTemporaryFile() as generated_values_file:
             yaml.dump(self.spec['config'], values_file)


### PR DESCRIPTION
Reverts 2i2c-org/pilot-hubs#211

I found the large number of ssh keys in the cloudbank project!
https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-b/instances/nfs-server-01?project=cb-1003-1696&instancessize=50 

I've removed it.