### PR TITLE
Ensure we are adding all the callback urls if hub has multiple domains

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -69,7 +69,7 @@ class KeyProvider:
                 client['client_id'],
                 {
                     # Don't remove other callback URLs
-                    'callbacks': client['callbacks'] + [callback_url]
+                    'callbacks': client['callbacks'] + missing_callbacks
                 }
             )
 

--- a/auth.py
+++ b/auth.py
@@ -47,24 +47,29 @@ class KeyProvider:
         created_client = self.auth0.clients.create(client)
         return created_client
 
-    def _get_callback_url_list(domains):
+    def _get_callback_url_list(self, domains):
         if isinstance(domains, list):
             callbacks = []
-            for domain in all_domains:
+            for domain in domains:
                 callbacks.append(f'https://{domain}/hub/oauth_callback')
-            return callback_urls
+            return callbacks
 
         return [f'https://{domains}/hub/oauth_callback']
 
     def _ensure_client_callback(self, client, domains):
         callback_urls = self._get_callback_url_list(domains)
+        missing_callbacks = []
 
-        if 'callbacks' not in client or callback_url not in client['callbacks']:
+        for callback_url in callback_urls:
+            if 'callbacks' not in client or callback_url not in client['callbacks']:
+                missing_callbacks.append(callback_url)
+
+        if missing_callbacks:
             self.auth0.clients.update(
                 client['client_id'],
                 {
                     # Don't remove other callback URLs
-                    'callbacks': client['callbacks'] + callback_urls
+                    'callbacks': client['callbacks'] + [callback_url]
                 }
             )
 

--- a/hub.py
+++ b/hub.py
@@ -6,6 +6,7 @@ import hmac
 import os
 import json
 import pytest
+import random
 import tempfile
 from ruamel.yaml import YAML
 from ruamel.yaml.scanner import ScannerError
@@ -305,10 +306,10 @@ class Hub:
         deployments and error out.
         """
 
-        if self.spec['auth0'].get('domain', False):
-            hub_domain = self.spec['auth0']['domain']
-        elif isinstance(self.spec['domain'], str):
+        if isinstance(self.spec['domain'], str):
             hub_domain = self.spec['domain']
+        else:
+            hub_domain = random.choice(self.spec['domain'])
 
         hub_url = f'https://{hub_domain}'
         username='deployment-service-check'

--- a/hub.py
+++ b/hub.py
@@ -236,16 +236,9 @@ class Hub:
         # Allow explicilty ignoring auth0 setup
         if self.spec['auth0'].get('enabled', True):
 
-            # hub.spec['auth0']['domain'] takes precedence over hub.spec['domain']
-            # If hub.spec['auth0']['domain'], then hub.spec['domain'] must NOT be a list
-            if self.spec['auth0'].get('domain', False):
-                auth0_domain = self.spec['auth0']['domain']
-            elif isinstance(self.spec['domain'], str):
-                auth0_domain = self.spec['domain']
-
             client = auth_provider.ensure_client(
                 self.spec['name'],
-                auth0_domain,
+                self.spec['domain'],
                 self.spec['auth0']['connection']
             )
             # FIXME: We're hardcoding GenericOAuthenticator here

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -689,7 +689,6 @@ clusters:
         template: base-hub
         auth0:
           connection: google-oauth2
-          domain: mills.cloudbank.2i2c.cloud
         config:
           jupyterhub:
             homepage:


### PR DESCRIPTION
If hub has multiple domains linked to it, we need to add a callback url of the form `https://{domains}/hub/oauth_callback` in auth0 for each of them.

This should automate this task.