### PR TITLE
Make terraform more configurable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,7 +61,7 @@ module "gke" {
   node_pools = [
     {
       name               = "core-pool"
-      machine_type       = "n1-highmem-2"
+      machine_type       = var.core_node_machine_type
       min_count          = 1
       max_count          = 10
       local_ssd_count    = 0
@@ -76,8 +76,8 @@ module "gke" {
       version            = "1.17.12-gke.2502"
     },
     {
-      machine_type       = "n1-highmem-4"
       name               = "user-pool"
+      machine_type       = var.user_node_machine_type
       min_count          = 0
       max_count          = 10
       local_ssd_count    = 0
@@ -92,8 +92,8 @@ module "gke" {
       version            = "1.17.12-gke.2502"
     },
     {
-      machine_type       = "e2-standard-4"
       name               = "dask-worker-pool"
+      machine_type       = var.dask_worker_machine_type
       min_count          = 0
       max_count          = 10
       local_ssd_count    = 0

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -65,7 +65,7 @@ module "gke" {
       local_ssd_count    = 0
       disk_size_gb       = 100
       disk_type          = "pd-standard"
-      image_type         = "UBUNTU"
+      image_type         = "COS"
       auto_repair        = true
       auto_upgrade       = false
       preemptible        = false
@@ -81,7 +81,7 @@ module "gke" {
       local_ssd_count    = 0
       disk_size_gb       = 100
       disk_type          = "pd-ssd"
-      image_type         = "UBUNTU"
+      image_type         = "COS"
       auto_repair        = true
       auto_upgrade       = false
       preemptible        = false
@@ -99,7 +99,7 @@ module "gke" {
       # Fast startup is important here, so we get fast SSD disks
       # This pulls in user images much faster
       disk_type          = "pd-ssd"
-      image_type         = "UBUNTU"
+      image_type         = "COS"
       auto_repair        = true
       auto_upgrade       = false
       preemptible        = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,6 +55,8 @@ module "gke" {
   http_load_balancing        = false
   horizontal_pod_autoscaling = false
   network_policy             = true
+  # We explicitly set up a core pool, so don't need the default
+  remove_default_node_pool   = true
 
   node_pools = [
     {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -76,8 +76,8 @@ module "gke" {
       version            = "1.17.12-gke.2502"
     },
     {
-      name               = "user-pool-2020-09-29"
       machine_type       = "n1-highmem-4"
+      name               = "user-pool"
       min_count          = 0
       max_count          = 10
       local_ssd_count    = 0
@@ -92,8 +92,8 @@ module "gke" {
       version            = "1.17.12-gke.2502"
     },
     {
-      name               = "dask-worker-pool-2020-12-11"
       machine_type       = "e2-standard-4"
+      name               = "dask-worker-pool"
       min_count          = 0
       max_count          = 10
       local_ssd_count    = 0
@@ -126,10 +126,10 @@ module "gke" {
       default-node-pool = true
       "hub.jupyter.org/pool-name" = "core-pool"
     }
-    user-pool-2020-09-29 = {
+    user-pool = {
       "hub.jupyter.org/pool-name" = "user-pool"
     }
-    dask-worker-pool-2020-12-11 = {
+    dask-worker-pool = {
       "hub.jupyter.org/pool-name" = "dask-worker-pool"
     }
   }
@@ -137,12 +137,12 @@ module "gke" {
   node_pools_taints = {
     all = []
 
-    user-pool-2020-09-29 = [{
+    user-pool = [{
         key    = "hub.jupyter.org_dedicated"
         value  = "user"
         effect = "NO_SCHEDULE"
     }]
-    dask-worker-pool-2020-12-11 = [{
+    dask-worker-pool = [{
         key    = "k8s.dask.org_dedicated"
         value  = "worker"
         effect = "NO_SCHEDULE"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,5 +20,5 @@ variable "zone" {
 
 variable "regional_cluster" {
   type = string
-  default = "true"
+  default = "false"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,3 +22,18 @@ variable "regional_cluster" {
   type = string
   default = "false"
 }
+
+variable "core_node_machine_type" {
+  type = string
+  default = "e2-highcpu-4"
+}
+
+variable "user_node_machine_type" {
+  type = string
+  default = "n1-standard-4"
+}
+
+variable "dask_worker_machine_type" {
+  type = string
+  default = "e2-highmem-2"
+}


### PR DESCRIPTION
- Node pool machine types are now configurable
- Node pool names no longer have dates in them. This was
  necessary with eksctl since it didn't properly recreate
  node pools - terraform does, so we can get rid of it.
- Disable unnecessary default node pool, since we explicitly
  create a core pool instead
- Use COS as base image for nodes. We used Ubuntu primarily for
  NFS client support. COS also supports NFS clients now, and
  is a smaller attack target
- Disable regional clusters by default - we don't need that
  much reliability, and it is expensive!



