### PR TITLE
Add paleohack2021 hackathon hub

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -237,7 +237,7 @@ clusters:
             singleuser:
               image:
                 name: quay.io/2i2c/paleohack-2021
-                tag: 2c7ff948c272
+                tag:  3c014454dd99
             hub:
               config:
                 Authenticator:
@@ -717,3 +717,62 @@ clusters:
                     - aculich@berkeley.edu
                     - jpercy@berkeley.edu
                   username_pattern: '^(.+@mills\.edu|yuvipanda@gmail\.com|choldgraf@gmail\.com|georgiana\.dolocan@gmail\.com|aculich@berkeley\.edu|jpercy@berkeley\.edu|deployment-service-check)$'
+  - name: hackathon-alpha
+    image_repo:  "us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/base-user"
+    provider: gcp
+    gcp:
+      key: secrets/hackathon-alpha.json
+      project: hackathon-2i2c-project-alpha
+      cluster: alpha-cluster
+      region: us-central1-b
+      nfs:
+        server: nfs-server-01
+        zone: us-central1-b
+    hubs:
+      - name: paleohack2021
+        domain: paleohack2021.hackathon.2i2c.cloud
+        template: base-hub
+        auth0:
+          connection: github
+        config:
+          jupyterhub:
+            scheduling:
+              userPlaceholder:
+                # Let's turn this back on during the hackathon
+                # Until then, keeping this off saves cost
+                enabled: false
+
+              userScheduler:
+                # Each user gets almost 1 anyway
+                enabled: false
+            homepage:
+              templateVars:
+                org:
+                  name: "PaleoHack 2021"
+                  logo_url: "https://raw.githubusercontent.com/LinkedEarth/Logos/master/pyleoclim_logo_full_white.png"
+
+                  url: "https://linkedearth.github.io/paleoHackathon/"
+                designed_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+                operated_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+                funded_by:
+                  name: "NSF Paleo Perspectives on Climate Change program"
+                  url: "https://www.nsf.gov/funding/pgm_summ.jsp?pims_id=5750"
+            singleuser:
+              memory:
+                limit: 15G
+                guarantee: 8G
+              cpu:
+                limit: 4
+                guarantee: 2
+              image:
+                name: quay.io/2i2c/paleohack-2021
+                tag:  3c014454dd99
+            hub:
+              config:
+                Authenticator:
+                  allowed_users: *paleohack_users
+                  admin_users: *paleohack_users

--- a/secrets/hackathon-alpha.json
+++ b/secrets/hackathon-alpha.json
@@ -1,0 +1,29 @@
+{
+	"type": "ENC[AES256_GCM,data:DnGzDloB/X9b0MRE++3F,iv:woUgLGf655zq+QIH4IeuzTzOxNUE9GjTw4qXW+MMDu8=,tag:k/E/fAs4ovdury7B/T03wQ==,type:str]",
+	"project_id": "ENC[AES256_GCM,data:hKKBPakRfSWQvc8ZQbmt+q3BIGEco63coKBZxw==,iv:ej8RaG2zZss4ea4b5+vYMktCB6AJ6fbzBMc/DNWdYxw=,tag:ZQvdtmF3HpynA/C7hNUKbg==,type:str]",
+	"private_key_id": "ENC[AES256_GCM,data:PV1lcSdtNKLBlUI6Gj+frXCRpc6ouINsWDZoijOrQS1bQ4D0xE/qaw==,iv:XGxbJNVyKBkdaFr4D0tzHUz0bGS3JeFLGMYLWygkiuo=,tag:vU+IzewQSpI33jtUmo/xzA==,type:str]",
+	"private_key": "ENC[AES256_GCM,data:wVw4PlJt920yJL5HEYlqkOoZNre2tUAc33GwtkpkzDnrdL2Aiw7w2VI+sIquung4hPI8kM/4SzMsquaVLSZhoeS4OVMWruxC8yxFMRbjWRAHkWbQwcvc79omIOxrHtMmCj/uPqPAVpkxOZpcORLSZSij6Ueu4z6FDpimT3zQDPcqLXaMVv3qDnIW7xHv9rr2sVD45HBJ/GrhSkSg2ODbdKfVcsD+xP2teK2NafQUMzMG9Pp9Osmk7O5IXV6vonzNg0D7aSnFjPeGVskm0gKN3scCYiWDS93NRQGQTg3Ms8C4JkSp/zuNPaUwTAQFaNGGJc2Xd7y/dVgwh4eiVMMiFg4iF+EeptH4VRfUwb45NFFUSEKdrJhRXJxv3jVFYzSPUb9kNkS06merCbwuImLVTys3QuFdp1eecggCGWfF7CEO0xlT8KKU1JYbMtP+mc3JKBQ9ohRWKa771mG7YOmXiocss2bXZCveo0G1aC/ozswP5cgRIQy7divmrjsiOcce7pLyiPXfGpBb+YsRwYpXobGmD8zziRMS87Rs292VaFUaJUec5xehMJfeAxuvV0AcX7+I4M1J2fG3+isGSs1b8GCUWU3Z8w5i4wSC0w6SfN1u6ZA/FZ1Ue8SxlJEag6Gku36vfyH3bqN6tDq+LE5ngmVyG7hYhChP4zTOuIlOzCxnzLZzYsDyW+eHg2HwBKIx6lXePxHsJv19DI794rOjhtnQXrOyah8EB7xcTxyiMiT/TRMeQ2mvahpWz4OkxJ30Rj32ObAoAQjO6U1bgpr7AWME8PLQpz0X1SjdkI0GMsv4edsxWoX9PAFS0RS8GM1JRj2R0SIxXGRcOVcsWWbcI879PSX1196BHgVmINXSVKB9hOX5GIISyYLWRYanFu9ANFl6wCt3QQymNesLMuNPBdq4ukANbTk10gjwSSbQsTgv8iJHvat0k3Yj52VOY9jYN4X8/SfL82BpnR5YJmW2ylkhkbIWSmstHrqXXfx6JD4Tkfa21ZDHMEemYusXqzAi4kdZVnd0urWlYUK/BZ5OdTEspo92jSF8QORggmCRNTjHb2HHcntPNTVzq9SlZpxzLd0ivzesgyYHYDMlCAWQd570lfe8Nc+UiOE82S8T1PV9xmR6jWM3yOdr/lphkSdHUWYuh+E5aEMPIsuLy+U+fjI4MMRyM8O9aKfn89Q2cUtaz8pAPJVQly9s9AhxCmo33CmKERnog70hjCY6G9bbiu8EYVxFNOXTy8R+JnppWYwWltarjPLeYtEssOFShwql/vS/gLuLzQ54Kso/OB8AdTFyLEpwsZun8V10tFsDwFCb2SxftGDq12ROcGm793xZdeOE5TYiMc9H+e4/Aq58mpVyc98O5/z5DcH2v1L0KYnJ85+IMsvJWvjzuCKc8WQXBPn0h08rzkCSjXvpIpxDUJXcE7QoL3r2jao7IEml2xNog7aLbmgIUas5nktG8CoMSl7YdSgMhs4VV4MdZNcCxOotkD7V2FRTLiefBQQaqVWtF0Ugb5ieGALufPiOoulWv+TF69v4769H1qtI1oSgi0K42qDbq1qGh49K6lxkR/iyPWd6S+I5IgdVUEYrpq+u6LLONzxgqoru1zycvb0z9982DA1DjwJXLuoIiFgbhr/kwfBTcV7dgFH9t054y+pUY+wA8HXe+ycxz71ViLok9Czx367MfbqINj/fK0PB7MLTkxV/tsS7m/u0aWE4creOwxz9bx8L0xQpgI4RTXCfj8nlsAboPpM6HVsYMQcP2W+Va+40M141ZAtKCKfSqXP9oCrtTz9hZL7XA29vj4SlNs5wD2oGfQEt55OAvX2Dx8n+ZCPtl0/keYSl+yybVNhROGMtG2CprQ/Iu7UEJzRoXoCuxQRUBRJHvI54VMGvtFKmRSVdNXW7GRNnWvG+jCcmiXx6S7WB+/TH8HJxousAvNLhJPIhqMjNjgCf/zpT2jEMNIEExuxWC2OPlC/FhYPW7z8vhNG4n1W6Y1IvvmC3hh4CyqFqtp2XB4KNBufL72G+P9b194bMs6WJm+PyhZc2hNHXOv9Ot/wPeLHHYHIqj8x/ZbGhNrh5Y4kLxuFuAVhfSx4QmtrhEi7EDsjt2LKbk78z3ylCDl+BCQySCu8irS+F77VPTr8GjR9aNzpkmyxP/zHCYApdwYQEWo1+btl11YuMaNkfEUpDtcJc9DtM/062Ple6grEOFP4NGOEUU3szqz2k1hSnaVsijR7E80Ftfc4ADQr/i7m/k+5AOXqmurkBdQ+bdKI9,iv:YW2cQ+iyeiqDttHMR56LnJvlDsWelO2H+8gMhtAi3GI=,tag:BUtVfcWk023ejAXq1BkF4Q==,type:str]",
+	"client_email": "ENC[AES256_GCM,data:C0PaJCooqednldf57ZyqY3EZg39TyxbMIwI9IMA/ixdAVeR/J20n73iR1TXlyM4Z3NAPDzwmItBnMIdu6oeZRA==,iv:AojOTu4bCoVH6PeehVjY2EtDifbPIemple2aeXGbcZw=,tag:g+E7hn1ar3qRWIis41GiHw==,type:str]",
+	"client_id": "ENC[AES256_GCM,data:7ZYjkrRFu1VUKemBQrVHm64m3IPp,iv:6awmvz07YwzhEsWUB0Qs8GlYK34+b4mRYjOd7UGGyPA=,tag:8OgvnDbYOlLtuyLDlk8z4A==,type:str]",
+	"auth_uri": "ENC[AES256_GCM,data:CG2Fn8JsKyVgUMaojli5uJvTRNh5oOLhlVpsKYy8szZ61LBxkQY5Sqc=,iv:27V9UpFlhV3XW3bX6Wn+lb4oHLOBiZL4fZ5+ztGw9TI=,tag:k6ZxpxOsOHW3rx+qZDxrtA==,type:str]",
+	"token_uri": "ENC[AES256_GCM,data:at19MOUGLrONM0c5pbsOThxWR/GOgoiQ/ZxLbQGCi9Yit1w=,iv:NKF/DD7cp6GClc3uipT4B5mbnNdB+MwM8MUUTNaLaS4=,tag:rQXrQigCM1U+FE+88Tj1ow==,type:str]",
+	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:NpuLZcWVE4TjNxc8mcA2bfw636Xnfi5lbsWTZIIM1qm7idLBG4plbkvi,iv:+EDlp4N2yEzfKYNgmAn1dihWUaS9+QZzkoY2BPzY3Tw=,tag:iAmZOnJQ2FlTi1PwJT/LYQ==,type:str]",
+	"client_x509_cert_url": "ENC[AES256_GCM,data:AjIVqnKjD9JxqarxxswNVZI3zipO4/ZlQ5AkKoEFcGydLJ+UPfEqgIk1HwvoYYNBbzmuRU/56wiUKlRs3YADdSz2RdzWOFbqKBmtJF6POThuPmzDZ3v2gQX6rJk75ZoAOqJeS1/nqtC2zu8WXN49uHjSRNU=,iv:EU/yUftVV+2sd27FoJBHBZgk99r4H0HFWzrxxkTAZq0=,tag:t5+69t043+hf6ropDBDXkA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2021-02-16T13:46:34Z",
+				"enc": "CiQA4OM7eBqL4WZ8Ibep0ctVbBDdNURi5tsBhukjTzQEWFy/nrUSSQC/Eu+qQQc/YlUDh24JRPQTP8CKA9e40sP5WJMmX6swwm6bzaRBZik0Wkbrpcle9jc9s/x+xLrv8B7qzsdWFBj46ESU4i7xSNk="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2021-02-16T13:46:36Z",
+		"mac": "ENC[AES256_GCM,data:34OdzXKaljdvGJQlj7SoXkfML/p8er1qMaqo4pdrOO09sGzCk2gH7E3iBpemDGmVwXF9L1T/RO11HlG1zMokcd3Nw8pJPYSjQ9trPEWuFyyuc6U6in3/ULwufhKbX6AE0BDs+DpJOM6ryGoMhbx2cDY+dEL6TcD2xDhrEzSxGKY=,iv:dmd7zS9iVUK8BFLxlAY6dlLYacLlMV6RaNaRjWuENd8=,tag://vmbBTnofqz+x2y1uAQKA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/terraform/hackathon-2i2c-project-alpha.tfvars
+++ b/terraform/hackathon-2i2c-project-alpha.tfvars
@@ -1,0 +1,2 @@
+prefix = "alpha"
+project_id = "hackathon-2i2c-project-alpha"


### PR DESCRIPTION
We want to pass through cloud costs to our users.
Putting them in their own cloud project is the cleanest
and most transparent way to do this. I've created a project
called 'hackathon-2i2c-project-alpha' for it, and set up
the hub there. This PR adds the secret service account and
the hubs.yaml config for it.

I've also manually created the NFS directory!