### PR TITLE
terraform: NEVER DELETE THE CLUSTER

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,6 +58,10 @@ module "gke" {
   # We explicitly set up a core pool, so don't need the default
   remove_default_node_pool   = true
 
+  # NEVER DELETE THE CLUSTER WITHOUT DOUBLE ASKING USER
+  lifecycle {
+    prevent_destroy = true
+  }
   node_pools = [
     {
       name               = "core-pool"


### PR DESCRIPTION
Terraform might need to delete & recreate clusters
under some circumstances. This will bring everything down.
Thankfully at least on GKE this doesn't delete any persistent
disks, avoiding data loss. But, let's make sure it doesn't
happen again.