### PR TITLE
Create nfs home directory with helm hook

### DIFF
--- a/hub-templates/base-hub/templates/nfs-pvc.yaml
+++ b/hub-templates/base-hub/templates/nfs-pvc.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteMany
   nfs:
     server: {{ .Values.nfsPVC.nfs.serverIP | quote}}
-    path: "{{ .Values.nfsPVC.nfs.shareName }}"
+    path: "{{ .Values.nfsPVC.nfs.baseShareName }}/{{ .Release.Name }}"
   mountOptions:
     - soft
     - noatime

--- a/hub-templates/base-hub/templates/nfs-share-creater.yaml
+++ b/hub-templates/base-hub/templates/nfs-share-creater.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.nfsPVC.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nfs-share-creator
+  labels:
+    hub.jupyter.org/deletable: "true"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "10"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: dummy
+          image: busybox
+          env:
+            - name: NFS_SHARE_NAME
+              value: "{{ .Values.nfsPVC.nfs.baseShareName }}/{{ .Release.Name }}"
+          command:
+            - /bin/sh
+            - -c
+            - "mkdir -p ${NFS_SHARE_NAME} && chown 1000:1000 ${NFS_SHARE_NAME}"
+          volumeMounts:
+            - name: home-base
+              mountPath: {{ .Values.nfsPVC.nfs.baseShareName | quote }}
+      volumes:
+        - name: home-base
+          nfs:
+            server: {{ .Values.nfsPVC.nfs.serverIP | quote}}
+            path: {{ .Values.nfsPVC.nfs.baseShareName | quote}}
+{{ end }}

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -18,7 +18,7 @@ nfsPVC:
   enabled: true
   nfs:
     serverIP: nfs-server-01
-    shareName: /export/home-01
+    baseShareName: /export/home-01/homes
 
 jupyterhub:
   ingress:

--- a/hub-templates/daskhub/Chart.lock
+++ b/hub-templates/daskhub/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://dask.org/dask-gateway-helm-repo/
   version: 0.9.0
 digest: sha256:de2e3d8c0e278fef2d15c3a583422c6f148e290b7133ba00c5ba259ce4b48c0d
-generated: "2020-12-09T16:30:33.83066+05:30"
+generated: "2021-02-19T21:15:21.045799+05:30"


### PR DESCRIPTION
We need to create the home directory for a hub
before it can be mounted with our home-nfs PVC.
We were sshing into the NFS server for this before,
but that was flaky and broke. This is closer to the
'right' way to do it.

Fixes #206