### PR TITLE
Disable user placeholders for hubs by default

### DIFF
--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -30,7 +30,7 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 1
+      replicas: 0
     podPriority:
       enabled: true
       globalDefault: false


### PR DESCRIPTION
Extra spawn time is ok for now, since most hubs
are empty most of the time.