### PR TITLE
Replace nodeSelector with nodeAffinity for singleuser notebook servers.

### DIFF
--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -47,16 +47,6 @@ jupyterhub:
           memory: 64Mi
         limits:
           memory: 1G
-    userPods:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-            - key: hub.jupyter.org/pool-name
-              operator: In
-              values:
-              - user-pool
-          weight: 100
   prePuller:
     continuous:
       enabled: false
@@ -96,6 +86,14 @@ jupyterhub:
         subPath: _shared
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
+    extraNodeAffinity:
+      preferred:
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: hub.jupyter.org/pool-name
+              operator: In
+              values: [user-pool]
     image:
       name: set_automatically_by_automation
       tag: 4066a62

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -78,6 +78,16 @@ jupyterhub:
       enabled: false
       letsencrypt:
         contactEmail: yuvipanda@gmail.com
+  userAffinity:
+    nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+            - key: hub.jupyter.org/pool-name
+              operator: In
+              values:
+              - user-pool
+          weight: 100
   singleuser:
     admin:
       extraVolumeMounts:
@@ -86,8 +96,6 @@ jupyterhub:
         subPath: _shared
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
-    nodeSelector:
-      hub.jupyter.org/pool-name: user-pool
     image:
       name: set_automatically_by_automation
       tag: 4066a62
@@ -186,3 +194,19 @@ jupyterhub:
             return super().start(*args, **kwargs)
 
         c.JupyterHub.spawner_class = CustomSpawner
+      06-custom-affinity: |
+        node_selector = dict(
+            matchExpressions=[
+                dict(
+                    key="hub.jupyter.org/pool-name",
+                    operator="In",
+                    values=["user-pool"],
+                )
+            ],
+        )
+        c.KubeSpawner.node_affinity_preferred.append(
+            dict(
+                weight=100,
+                preference=node_selector,
+            ),
+        )

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -47,6 +47,16 @@ jupyterhub:
           memory: 64Mi
         limits:
           memory: 1G
+    userPods:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+            - key: hub.jupyter.org/pool-name
+              operator: In
+              values:
+              - user-pool
+          weight: 100
   prePuller:
     continuous:
       enabled: false
@@ -78,16 +88,6 @@ jupyterhub:
       enabled: false
       letsencrypt:
         contactEmail: yuvipanda@gmail.com
-  userAffinity:
-    nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-            - key: hub.jupyter.org/pool-name
-              operator: In
-              values:
-              - user-pool
-          weight: 100
   singleuser:
     admin:
       extraVolumeMounts:
@@ -194,19 +194,3 @@ jupyterhub:
             return super().start(*args, **kwargs)
 
         c.JupyterHub.spawner_class = CustomSpawner
-      06-custom-affinity: |
-        node_selector = dict(
-            matchExpressions=[
-                dict(
-                    key="hub.jupyter.org/pool-name",
-                    operator="In",
-                    values=["user-pool"],
-                )
-            ],
-        )
-        c.KubeSpawner.node_affinity_preferred.append(
-            dict(
-                weight=100,
-                preference=node_selector,
-            ),
-        )

--- a/hub.py
+++ b/hub.py
@@ -312,8 +312,8 @@ class Hub:
                 hub_url,
                 test_notebook_path,
                 username=username,
-                server_creation_timeout=300,
-                kernel_execution_timeout=300, # This doesn't do anything yet
+                server_creation_timeout=360,
+                kernel_execution_timeout=360, # This doesn't do anything yet
                 create_user=True,
                 delete_user=False, # To be able to delete its server in case of failure
                 stop_server=True, # If the health check succeeds, this will delete the server


### PR DESCRIPTION
This will allow the user servers to run on core nodes from the core pool too and potentially make server spawn faster.
Should fix the timeout errors seen in the deployments tests that we run.

This PR tries to replicate the z2jh behavior of  `scheduling.userPods.nodeAffinity`.

### Things that I'm unsure of:
- I'm not sure if setting the node affinity in both `KubeSpawner` and `jupyterhub.userAffinity` was necessary, as setting it only in KubeSpawner seems to produce the desired behaviour:
![single-user-server-affinity](https://user-images.githubusercontent.com/7579677/109521827-60b45680-7ab6-11eb-97ea-7a3eac835df5.png)
- Is there an issue that we have 2 node affinities set for the single user servers and they have the same weight?
- If so, is there a way to remove the one coming from z2jh?
 
cc @yuvipanda and @consideRatio