### PR TITLE
Allow requester pays access to cloud datasets

### DIFF
--- a/hub-templates/daskhub/templates/service-account.yaml
+++ b/hub-templates/daskhub/templates/service-account.yaml
@@ -1,0 +1,42 @@
+{{- define "daskhub.serviceAccountName" -}}
+{{.Release.Name}}-user-sa
+{{- end }}
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: {{ include "daskhub.serviceAccountName" . }}
+spec:
+  displayName: {{ .Release.Name }} hub user service account
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: workload-identity-binding
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: {{ include "daskhub.serviceAccountName" . }}
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - serviceAccount:{{ .Values.iam.projectId }}.svc.id.goog[{{ .Release.Namespace }}/user-sa]
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: sa-requester-pays-binding
+spec:
+  member: serviceAccount:{{ include "daskhub.serviceAccountName" . }}@{{ .Values.iam.projectId }}.iam.gserviceaccount.com
+  role: roles/serviceusage.serviceUsageConsumer
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/{{ .Values.iam.projectId }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: {{ include "daskhub.serviceAccountName" .}}@{{ .Values.iam.projectId }}.iam.gserviceaccount.com
+  name: user-sa

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -10,8 +10,16 @@ base-hub:
          hub.jupyter.org/network-access-proxy-http: "true"
 
       networkPolicy:
-        # Needed for talking to the proxy pod
         egress:
+          # Needed to talk to metadata server.
+          # see https://github.com/2i2c-org/pilot-hubs/issues/280
+          - to:
+              - ipBlock:
+                  cidr: 127.0.0.1/32
+            ports:
+              - port: 988
+                protocol: TCP
+          # Needed for talking to the proxy pod
           - ports:
               - port: 8000
                 protocol: TCP

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -40,6 +40,7 @@ base-hub:
         # without an explicit identity
         # FIXME: Provide an explicit identity for users instead
         blockWithIptables: false
+      serviceAccountName: user-sa
       extraEnv:
         # The default worker image matches the singleuser image.
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
@@ -97,6 +98,7 @@ dask-gateway:
     backend:
       scheduler:
         extraPodConfig:
+          serviceAccountName: user-sa
           tolerations:
             # Let's put schedulers on notebook nodes, since they aren't ephemeral
             # dask can recover from dead workers, but not dead schedulers
@@ -123,6 +125,7 @@ dask-gateway:
             runAsGroup: 1000
             runAsUser: 1000
         extraPodConfig:
+          serviceAccountName: user-sa
           securityContext:
             fsGroup: 1000
           tolerations:

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -117,6 +117,9 @@ clusters:
         auth0:
           connection: google-oauth2
         config:
+          iam:
+            # FIXME: Automatically inject this
+            projectId: two-eye-two-see
           base-hub:
             jupyterhub:
               homepage:
@@ -314,6 +317,8 @@ clusters:
         auth0:
           connection: google-oauth2
         config:
+          iam:
+            projectId: two-eye-two-see
           base-hub:
             jupyterhub:
               singleuser:
@@ -388,6 +393,9 @@ clusters:
         auth0:
           connection: github
         config:
+          iam:
+            # FIXME: Automatically inject this
+            projectId: two-eye-two-see
           base-hub:
             jupyterhub:
               singleuser:


### PR DESCRIPTION
- Move networkpolicy around so pods can get access
  to the GKE metadata server to authenticate themselves.
- Create a Google Cloud Service Account for each
  hub, via the Google Cloud Config connector[1]
- Bind the Google Cloud SA to a Kubernetes SA
  via Workload Identity[2]
- Give our Google Cloud SA the `serviceusage.services.use`
  permission (via `role.serviceusage.serviceUsageConsumer`).
  This is required for enabling requesterPays[3] access
  to other cloud datasets
- Mount the Kubernetes SA into our user pods & dask pods, so any
  google cloud access from it is authenticated properl
- Require projectId from daskhub config, since we derive
  Google Cloud SA names from that.

[1]: https://cloud.google.com/config-connector/docs/overview
[2]:
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
[3]: https://cloud.google.com/storage/docs/requester-pays
