### PR TITLE
Add a SCRATCH_BUCKET per dask hub

### DIFF
--- a/hub-templates/daskhub/templates/env-vars.yaml
+++ b/hub-templates/daskhub/templates/env-vars.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cloud-env-vars
+data:
+  scratch-bucket-name: {{ include "daskhub.scratchBucket.name" . }}
+  scratch-bucket-protocol: "gcs"

--- a/hub-templates/daskhub/templates/storage.yaml
+++ b/hub-templates/daskhub/templates/storage.yaml
@@ -1,0 +1,30 @@
+{{- define "daskhub.scratchBucket.name" -}}
+{{ .Values.iam.projectId }}-{{ .Release.Name }}-scratch-bucket
+{{- end }}
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  annotations:
+    cnrm.cloud.google.com/force-destroy: "false"
+  name: {{ include "daskhub.scratchBucket.name" . }}
+spec:
+  bucketPolicyOnly: true
+  lifecycleRule:
+    - action:
+        type: Delete
+      condition:
+        age: 7
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: scratch-bucket-binding
+spec:
+  member: serviceAccount:{{ include "daskhub.serviceAccountName" . }}@{{ .Values.iam.projectId }}.iam.gserviceaccount.com
+  # This gives users the ability to delete the bucket too :(
+  # But without this, I think you can't list objects in the bucket
+  role: roles/storage.admin
+  resourceRef:
+    apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    kind: StorageBucket
+    name: {{ include "daskhub.scratchBucket.name" . }}

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -44,11 +44,48 @@ base-hub:
       extraEnv:
         # The default worker image matches the singleuser image.
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+        SCRATCH_BUCKET_PROTOCOL:
+          valueFrom:
+            configMapKeyRef:
+              name: cloud-env-vars
+              key: scratch-bucket-protocol
+        SCRATCH_BUCKET_NAME:
+          valueFrom:
+            configMapKeyRef:
+              name: cloud-env-vars
+              key: scratch-bucket-name
     hub:
       networkPolicy:
         enabled: false
       extraConfig:
-        daskhub-01-add-dask-gateway-values: |
+        daskhub-01-dependent-env-vars: |
+          # Explicitly add user env vars that derive from other env vars
+          # When we use the dict z2jh form, they don't preserve ordering!
+          # Since the env var you refer to must already be defined, this
+          # doesn't work based on the name you have.
+          dependent_env_vars = [
+            {
+              'name': 'SCRATCH_BUCKET',
+              'value': "$(SCRATCH_BUCKET_PROTOCOL)://$(SCRATCH_BUCKET_NAME)/$(JUPYTERHUB_USER)"
+            },{
+              'name': 'PANGEO_SCRATCH',
+              'value': '$(SCRATCH_BUCKET)'
+            }
+          ]
+
+          from kubernetes import client
+
+          def modify_pod_hook(spawner, pod):
+            # FIXME: Make sure sidecars are never first containers
+            user_container = pod.spec.containers[0]
+            for denv in dependent_env_vars:
+              user_container.env.append(
+                client.V1EnvVar(**denv)
+              )
+            return pod
+          c.KubeSpawner.modify_pod_hook = modify_pod_hook
+
+        daskhub-02-add-dask-gateway-values: |
           # 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.
           # 2. Adds the URL for the Dask Gateway JupyterHub service.
           import os


### PR DESCRIPTION
A temporary bucket that's cleared every 7 days,
and provides full access to all the users on that
hub. See
https://github.com/pangeo-data/pangeo-cloud-federation/issues/610
for reasons why this is very useful.