### PR TITLE
Support using ORCID as authentication

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -3,6 +3,14 @@ from auth0.v3.management import Auth0
 from auth0.v3.authentication import GetToken
 import os
 
+# What key in the authenticated user's profile to use as hub username
+# This shouldn't be changeable by the user!
+USERNAME_KEYS = {
+    'github': 'nickname',
+    'google-oauth2': 'email',
+    'ORCID': 'sub'
+}
+
 
 class KeyProvider:
     def __init__(self, domain, client_id, client_secret):
@@ -111,17 +119,12 @@ class KeyProvider:
         Return z2jh config for auth0 authentication for this JupyterHub
         """
 
-        # default to using emails as usernames
-        username_key = 'email'
-        if connection_name == 'github':
-            # Except for GitHub, where we use the username
-            username_key = 'nickname'
         auth = {
             'authorize_url': f'https://{self.domain}/authorize',
             'token_url': f'https://{self.domain}/oauth/token',
             'userdata_url': f'https://{self.domain}/userinfo',
             'userdata_method': 'GET',
-            'username_key': username_key,
+            'username_key': USERNAME_KEYS[connection_name],
             'client_id': client['client_id'],
             'client_secret': client['client_secret'],
             'scope': ['openid', 'name', 'profile', 'email']

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -186,3 +186,23 @@ jupyterhub:
             return super().start(*args, **kwargs)
 
         c.JupyterHub.spawner_class = CustomSpawner
+
+      06-custom-authenticator: |
+        from oauthenticator.generic import GenericOAuthenticator
+        from traitlets import Unicode
+
+        class CustomOAuthenticator(GenericOAuthenticator):
+          async def authenticate(self, *args, **kwargs):
+            resp = await super().authenticate(*args, **kwargs)
+            if self.username_key == 'sub':
+              # auth0 returns 'sub' in the form of <provider>|<id>. For our
+              # friendly names, we just want <id>, since we don't support multiple
+              # authentication methods in the same hub
+              # This could've been a lambda set to username_key,
+              # but we would need to know which authentication mechanism
+              # auth0 is sending us, so we can use sub / email / nick as
+              # needed. This method is simpler
+              resp['name'] = resp['name'].split('|')[-1]
+            return resp
+
+        c.JupyterHub.authenticator_class = CustomOAuthenticator

--- a/hub-templates/daskhub/templates/service-account.yaml
+++ b/hub-templates/daskhub/templates/service-account.yaml
@@ -5,6 +5,8 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
   name: {{ include "daskhub.serviceAccountName" . }}
+  annotations:
+    cnrm.cloud.google.com/project-id : {{ .Values.iam.projectId | quote }}
 spec:
   displayName: {{ .Release.Name }} hub user service account
 ---
@@ -12,6 +14,8 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicy
 metadata:
   name: workload-identity-binding
+  annotations:
+    cnrm.cloud.google.com/project-id : {{ .Values.iam.projectId | quote }}
 spec:
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -26,6 +30,8 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: sa-requester-pays-binding
+  annotations:
+    cnrm.cloud.google.com/project-id : {{ .Values.iam.projectId | quote }}
 spec:
   member: serviceAccount:{{ include "daskhub.serviceAccountName" . }}@{{ .Values.iam.projectId }}.iam.gserviceaccount.com
   role: roles/serviceusage.serviceUsageConsumer

--- a/hub-templates/daskhub/templates/storage.yaml
+++ b/hub-templates/daskhub/templates/storage.yaml
@@ -5,7 +5,9 @@ apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
   annotations:
+    cnrm.cloud.google.com/project-id : {{ .Values.iam.projectId | quote }}
     cnrm.cloud.google.com/force-destroy: "false"
+
   name: {{ include "daskhub.scratchBucket.name" . }}
 spec:
   bucketPolicyOnly: true
@@ -19,6 +21,8 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: scratch-bucket-binding
+  annotations:
+    cnrm.cloud.google.com/project-id : {{ .Values.iam.projectId | quote }}
 spec:
   member: serviceAccount:{{ include "daskhub.serviceAccountName" . }}@{{ .Values.iam.projectId }}.iam.gserviceaccount.com
   # This gives users the ability to delete the bucket too :(


### PR DESCRIPTION
- Add ORCID as a supported OAuth2 provider in
  Auth0. This is done in the Auth0 UI for now.
- ORCID returns 'sub' with useful info. Auth0 gives
  that to us in the form of `oauth2|orcid|<orcid-id>`.
  We want this to be *just* orcid, so we split all
  subs on | and pick the last ID.
