### PR TITLE
Remove nbinteract

### DIFF
--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -96,7 +96,7 @@ jupyterhub:
               values: [user-pool]
     image:
       name: set_automatically_by_automation
-      tag: 4066a62
+      tag: 638350c
     storage:
       type: static
       static:

--- a/images/user/environment.yml
+++ b/images/user/environment.yml
@@ -35,7 +35,6 @@ dependencies:
     - voila==0.1.23
     - nbgitpuller==0.9.*
     - jupyter-resource-usage==0.5.0
-    - nbinteract==0.2.5
     - jupytext==1.6.*
     - RISE==5.6.1
     - jupyter_contrib_nbextensions==0.5.1


### PR DESCRIPTION
It causes issues with newer version of nbconvert,
and isn't super widely used either.

See https://github.com/2i2c-org/pilot/issues/57