### PR TITLE
[WIP] Allow admins to rename user home directories

### DIFF
--- a/hub-templates/base-hub/templates/nfs-share-creater.yaml
+++ b/hub-templates/base-hub/templates/nfs-share-creater.yaml
@@ -27,14 +27,14 @@ spec:
           image: busybox
           env:
             - name: NFS_SHARE_NAME
-              value: "{{ .Values.nfsPVC.nfs.baseShareName }}/{{ .Release.Name }}"
+              value: "{{ .Values.nfsPVC.nfs.clusterMountPath }}/{{ .Release.Name }}"
           command:
             - /bin/sh
             - -c
             - "mkdir -p ${NFS_SHARE_NAME} && chown 1000:1000 ${NFS_SHARE_NAME}"
           volumeMounts:
             - name: home-base
-              mountPath: {{ .Values.nfsPVC.nfs.baseShareName | quote }}
+              mountPath: {{ .Values.nfsPVC.nfs.clusterMountPath | quote }}
       volumes:
         - name: home-base
           nfs:

--- a/hub-templates/base-hub/templates/nfs-share-creater.yaml
+++ b/hub-templates/base-hub/templates/nfs-share-creater.yaml
@@ -27,14 +27,14 @@ spec:
           image: busybox
           env:
             - name: NFS_SHARE_NAME
-              value: "{{ .Values.nfsPVC.nfs.clusterMountPath }}/{{ .Release.Name }}"
+              value: "{{ .Values.nfsPVC.nfs.baseShareName }}/{{ .Release.Name }}"
           command:
             - /bin/sh
             - -c
             - "mkdir -p ${NFS_SHARE_NAME} && chown 1000:1000 ${NFS_SHARE_NAME}"
           volumeMounts:
             - name: home-base
-              mountPath: {{ .Values.nfsPVC.nfs.clusterMountPath | quote }}
+              mountPath: {{ .Values.nfsPVC.nfs.baseShareName | quote }}
       volumes:
         - name: home-base
           nfs:

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -19,6 +19,7 @@ nfsPVC:
   nfs:
     serverIP: nfs-server-01
     baseShareName: /export/home-01/homes
+    clusterMountPath: /home/jovyan/shared-readwrite/user-homes
 
 jupyterhub:
   ingress:
@@ -81,8 +82,10 @@ jupyterhub:
   singleuser:
     admin:
       extraVolumeMounts:
-      - name: home
-        mountPath: /home/jovyan/shared-readwrite
+      - name: homes
+        mountPath: /home/jovyan/shared-readwrite/user-homes
+      - name: public
+        mountPath: /home/jovyan/public
         subPath: _shared
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
@@ -103,8 +106,8 @@ jupyterhub:
         pvcName: home-nfs
         subPath: '{username}'
       extraVolumeMounts:
-      - name: home
-        mountPath: /home/jovyan/shared
+      - name: public
+        mountPath: /home/jovyan/public
         subPath: _shared
         readOnly: true
     memory:

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
     admin:
       extraVolumeMounts:
       - name: home
-        mountPath: /home/jovyan/admin-readwrite/user-homes
+        mountPath: /home/jovyan/admin/user-homes
       - name: home
         mountPath: /home/jovyan/shared-readwrite
         subPath: _shared

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -19,7 +19,6 @@ nfsPVC:
   nfs:
     serverIP: nfs-server-01
     baseShareName: /export/home-01/homes
-    clusterMountPath: /home/jovyan/shared-readwrite/user-homes
 
 jupyterhub:
   ingress:
@@ -82,10 +81,10 @@ jupyterhub:
   singleuser:
     admin:
       extraVolumeMounts:
-      - name: homes
-        mountPath: /home/jovyan/shared-readwrite/user-homes
-      - name: public
-        mountPath: /home/jovyan/public
+      - name: home
+        mountPath: /home/jovyan/admin-readwrite/user-homes
+      - name: home
+        mountPath: /home/jovyan/shared-readwrite
         subPath: _shared
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
@@ -106,8 +105,8 @@ jupyterhub:
         pvcName: home-nfs
         subPath: '{username}'
       extraVolumeMounts:
-      - name: public
-        mountPath: /home/jovyan/public
+      - name: home
+        mountPath: /home/jovyan/shared
         subPath: _shared
         readOnly: true
     memory:


### PR DESCRIPTION
I'm not sure at all about this and I would be super grateful if got some help understanding this.

What *I think* the pilot-hubs persistent storage setup looks like:
- there is a nfs server for persistent storage
    - it's running at: `serverIP: nfs-server-01`
- nfs baseShareName is the location on the nfs server where all the home directories are
    - `baseShareName: /export/home-01/homes`
    - each "release" (staging, dask-staging, etc) gets their own volume (`staging-home-nfs`, `dask-staging-home-nfs` etc)
- `baseShareName` is also used to mount this nfs share inside the cluster (is it ???). We're mirroring the file hierarchy of the nfs server inside our cluster.

The way I understood the issue is that we want another "pointer" in our cluster to the location in the nfs server where the home dirs actually are. This pointer has to be somewhere where all the admins have rw access.

What this PR tries to do is to mount the nfs share (where the home dirs are) to a new location inside the cluster (`clusterMountPath`).

P.S. I read the https://docs.datahub.berkeley.edu/en/latest/admins/storage.html which seemed similar with the setup we have here (it's just implemented differently)

Closes https://github.com/2i2c-org/pilot-hubs/issues/277