### PR TITLE
Use JupyterLab by default in justiceinnovationlab

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -203,6 +203,8 @@ clusters:
                 funded_by:
                   name: 2i2c
                   url: https://2i2c.org
+            singleuser:
+              defaultUrl: /lab
             hub:
               config:
                 Authenticator:


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/pilot/issues/60