### PR TITLE
Switch JIL to GitHub auth

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -185,7 +185,7 @@ clusters:
         domain: justiceinnovationlab.pilot.2i2c.cloud
         template: base-hub
         auth0:
-          connection: google-oauth2
+          connection: github
         config:
           jupyterhub:
             homepage:
@@ -209,13 +209,11 @@ clusters:
               config:
                 Authenticator:
                   admin_users:
-                    - yuvipanda@gmail.com
-                    - choldgraf@gmail.com
-                    - georgiana.dolocan@gmail.com
-                    - donald.braman@justiceinnovationlab.org
-                    - rory.pulvino@justiceinnovationlab.org
-                    - jared.fishman@justiceinnovationlab.org
-                  username_pattern: '^(.+@justiceinnovationlab\.org|yuvipanda@gmail\.com|choldgraf@gmail\.com|georgiana\.dolocan@gmail\.com|deployment-service-check)$'
+                    - yuvipanda
+                    - choldgraf
+                    - GeorgianaElena
+                    - donaldbraman
+                    - JILPulvino
       - name: pfw
         cluster: 2i2c
         domain: pfw.pilot.2i2c.cloud


### PR DESCRIPTION
Fixes #59

I also manually logged in to our NFS server, and renamed the directories
under `/export/home-01/homes/justiceinnovationlab` to match 
[new usernames](https://github.com/2i2c-org/pilot/issues/59#issuecomment-797651636)