### PR TITLE
Deploy jupyterhub-configurator

### DIFF
--- a/hub-templates/base-hub/Chart.yaml
+++ b/hub-templates/base-hub/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: base-hub
 # Let's keep this constant so other charts in this repo can depend on this easily
-version: 0.0.1-n534.h6b3cdb9
+version: 0.0.1-n534.h0a5b959
 dependencies:
   - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS

--- a/hub-templates/base-hub/Chart.yaml
+++ b/hub-templates/base-hub/Chart.yaml
@@ -3,9 +3,9 @@ appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: base-hub
 # Let's keep this constant so other charts in this repo can depend on this easily
-version: 0.0.1
+version: 0.0.1-n532.hde0dd1d
 dependencies:
- - name: jupyterhub
+  - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS
-   version: 0.11.1-n277.h61b0e003
-   repository: https://jupyterhub.github.io/helm-chart/
+    version: 0.11.1-n277.h61b0e003
+    repository: https://jupyterhub.github.io/helm-chart/

--- a/hub-templates/base-hub/Chart.yaml
+++ b/hub-templates/base-hub/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: base-hub
 # Let's keep this constant so other charts in this repo can depend on this easily
-version: 0.0.1-n532.hde0dd1d
+version: 0.0.1-n534.h6b3cdb9
 dependencies:
   - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS

--- a/hub-templates/base-hub/templates/configurator.yaml
+++ b/hub-templates/base-hub/templates/configurator.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: configurator
+  labels:
+    app: jupyterhub
+    component: configurator
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 10101
+      targetPort: 10101
+  selector:
+    app: jupyterhub
+    component: hub

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -136,7 +136,7 @@ jupyterhub:
           - jupyterhub_configurator.app
     image:
       name: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/agehub
-      tag: '0.0.1-n532.h8c2ddab'
+      tag: '0.0.1-n532.hde0dd1d'
     config:
       JupyterHub:
         authenticator_class: oauthenticator.generic.GenericOAuthenticator

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -135,8 +135,8 @@ jupyterhub:
           - -m
           - jupyterhub_configurator.app
     image:
-      name: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/agehub
-      tag: '0.0.1-n532.hde0dd1d'
+      name: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/pilot-hub
+      tag: '0.0.1-n534.h6b3cdb9'
     config:
       JupyterHub:
         authenticator_class: oauthenticator.generic.GenericOAuthenticator

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -81,9 +81,9 @@ jupyterhub:
   singleuser:
     admin:
       extraVolumeMounts:
-      - name: home
-        mountPath: /home/jovyan/shared-readwrite
-        subPath: _shared
+        - name: home
+          mountPath: /home/jovyan/shared-readwrite
+          subPath: _shared
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
     extraNodeAffinity:
@@ -91,9 +91,9 @@ jupyterhub:
         - weight: 100
           preference:
             matchExpressions:
-            - key: hub.jupyter.org/pool-name
-              operator: In
-              values: [user-pool]
+              - key: hub.jupyter.org/pool-name
+                operator: In
+                values: [user-pool]
     image:
       name: set_automatically_by_automation
       tag: 638350c
@@ -103,10 +103,10 @@ jupyterhub:
         pvcName: home-nfs
         subPath: '{username}'
       extraVolumeMounts:
-      - name: home
-        mountPath: /home/jovyan/shared
-        subPath: _shared
-        readOnly: true
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
     memory:
       guarantee: 256M
       limit: 1G
@@ -127,6 +127,16 @@ jupyterhub:
             - port: 443
               protocol: TCP
   hub:
+    services:
+      configurator:
+        url: http://configurator:10101
+        command:
+          - python3
+          - -m
+          - jupyterhub_configurator.app
+    image:
+      name: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/agehub
+      tag: '0.0.1-n532.h8c2ddab'
     config:
       JupyterHub:
         authenticator_class: oauthenticator.generic.GenericOAuthenticator
@@ -135,6 +145,26 @@ jupyterhub:
     networkPolicy:
       enabled: true
       ingress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  app: jupyterhub
+                  component: hub
+          ports:
+            - port: 8081
+              protocol: TCP
+        - from:
+            - podSelector:
+                matchLabels:
+                  app: jupyterhub
+                  component: proxy
+            - podSelector:
+                matchLabels:
+                  app: jupyterhub
+                  component: hub
+          ports:
+            - port: 10101
+              protocol: TCP
         - from:
             - namespaceSelector:
                 matchLabels:
@@ -179,7 +209,9 @@ jupyterhub:
       05-custom-admin: |
         from z2jh import get_config
         from kubespawner import KubeSpawner
-        class CustomSpawner(KubeSpawner):
+        from jupyterhub_configurator.mixins import ConfiguratorSpawnerMixin
+
+        class CustomSpawner(ConfiguratorSpawnerMixin, KubeSpawner):
           def start(self, *args, **kwargs):
             custom_admin = get_config('singleuser.admin', {})
             if custom_admin and self.user.admin:
@@ -190,6 +222,7 @@ jupyterhub:
                 self.volume_mounts += [volume for volume in extra_volume_mounts if volume not in self.volume_mounts]
 
             return super().start(*args, **kwargs)
+
 
         c.JupyterHub.spawner_class = CustomSpawner
 

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -135,8 +135,8 @@ jupyterhub:
           - -m
           - jupyterhub_configurator.app
     image:
-      name: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/pilot-hub
-      tag: '0.0.1-n534.h6b3cdb9'
+      name: quay.io/2i2c/pilot-hub
+      tag: '0.0.1-n534.h0a5b959'
     config:
       JupyterHub:
         authenticator_class: oauthenticator.generic.GenericOAuthenticator

--- a/hub-templates/chartpress.yaml
+++ b/hub-templates/chartpress.yaml
@@ -1,6 +1,6 @@
 charts:
   - name: base-hub
-    imagePrefix: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/age
+    imagePrefix: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/pilot-
     images:
       hub:
         valuesPath: jupyterhub.hub.image

--- a/hub-templates/chartpress.yaml
+++ b/hub-templates/chartpress.yaml
@@ -1,0 +1,6 @@
+charts:
+  - name: base-hub
+    imagePrefix: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/age
+    images:
+      hub:
+        valuesPath: jupyterhub.hub.image

--- a/hub-templates/chartpress.yaml
+++ b/hub-templates/chartpress.yaml
@@ -1,6 +1,6 @@
 charts:
   - name: base-hub
-    imagePrefix: us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/pilot-
+    imagePrefix: quay.io/2i2c/pilot-
     images:
       hub:
         valuesPath: jupyterhub.hub.image

--- a/hub-templates/images/hub/Dockerfile
+++ b/hub-templates/images/hub/Dockerfile
@@ -1,0 +1,7 @@
+# Should match the hub image used by version of chart in hub/requirements.yaml
+# If that changes, this should be changed too!
+FROM jupyterhub/k8s-hub:0.11.1-n298.hd9d7403b
+
+ENV CONFIGURATOR_VERSION 746e7285af40b9bafd227dae3f2e41d1a631a301
+
+RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configurator@${CONFIGURATOR_VERSION}


### PR DESCRIPTION
Simple deployment of https://github.com/yuvipanda/jupyterhub-configurator.

- Built into the hub image, as that's the easiest - we need
  the package there anyway, to use the mixin.
  Will probably move to its own container as a sidecar at
  some point soon.
- Seprate service named configurator for the proxy to be able to
  find it, even though it's in the same container as the hub!
  We can't expose more ports from the hub service, so the proxy
  can't actually reach port 10101 on the hub container. We need
  a new service, plus appropriate networlpolicy rules for this.
  This should be made simpler.
- Use configurator mixin to bring let the spawner take in dynamic
  configuration. This means spawns *will fail* if the configurator
  fails, and that's ok. Explicit decision to try make this work
  well.
- Chartpress to build and push the image. We use quay.io, since we
  don't want to push a copy of the image to each project. Hub images
  are pulled infrequently enough for this to be ok.

Ref #312