### PR TITLE
Unbreak deploys by fixing image tag

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -35,8 +35,9 @@ def build():
     config_file_path = Path(__file__).parent / "hubs.yaml"
     clusters = parse_clusters(config_file_path)
     for cluster in clusters:
-        with cluster.auth():
-            cluster.build_image()
+        if "image_repo" in cluster.spec:
+            with cluster.auth():
+                cluster.build_image()
 
 
 def deploy(cluster_name, hub_name, skip_hub_health_test):

--- a/deploy.py
+++ b/deploy.py
@@ -15,7 +15,8 @@ from auth import KeyProvider
 from hub import Hub, Cluster
 
 # Without `pure=True`, I get an exception about str / byte issues
-yaml = YAML(typ='safe', pure=True)
+yaml = YAML(typ="safe", pure=True)
+
 
 def parse_clusters(config_file_path):
     """
@@ -24,10 +25,7 @@ def parse_clusters(config_file_path):
     with open(config_file_path) as f:
         config = yaml.load(f)
 
-    return [
-        Cluster(cluster_yaml)
-        for cluster_yaml in config['clusters']
-    ]
+    return [Cluster(cluster_yaml) for cluster_yaml in config["clusters"]]
 
 
 def build():
@@ -51,12 +49,12 @@ def deploy(cluster_name, hub_name, skip_hub_health_test):
     # this, we'd have to manually generate credentials for each hub - and we
     # don't want to do that. Auth0 domains are tied to a account, and
     # this is our auth0 domain for the paid account that 2i2c has.
-    AUTH0_DOMAIN = '2i2c.us.auth0.com'
+    AUTH0_DOMAIN = "2i2c.us.auth0.com"
 
     k = KeyProvider(
         AUTH0_DOMAIN,
-        os.environ['AUTH0_MANAGEMENT_CLIENT_ID'],
-        os.environ['AUTH0_MANAGEMENT_CLIENT_SECRET']
+        os.environ["AUTH0_MANAGEMENT_CLIENT_ID"],
+        os.environ["AUTH0_MANAGEMENT_CLIENT_SECRET"],
     )
 
     # Each hub needs a unique proxy.secretToken. However, we don't want
@@ -68,17 +66,20 @@ def deploy(cluster_name, hub_name, skip_hub_health_test):
     # keep much state. We can rotate them by changing `PROXY_SECRET_KEY`.
     # However, if `PROXY_SECRET_KEY` leaks, that means all the hub's
     # proxy.secretTokens have leaked. So let's be careful with that!
-    PROXY_SECRET_KEY = bytes.fromhex(os.environ['PROXY_SECRET_KEY'])
+    PROXY_SECRET_KEY = bytes.fromhex(os.environ["PROXY_SECRET_KEY"])
 
     config_file_path = Path(__file__).parent / "hubs.yaml"
     clusters = parse_clusters(config_file_path)
 
     if cluster_name:
-        cluster = next((cluster for cluster in clusters if cluster.spec['name'] == cluster_name), None)
+        cluster = next(
+            (cluster for cluster in clusters if cluster.spec["name"] == cluster_name),
+            None,
+        )
         with cluster.auth():
             hubs = cluster.hubs
             if hub_name:
-                hub = next((hub for hub in hubs if hub.spec['name'] == hub_name), None)
+                hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
                 hub.deploy(k, PROXY_SECRET_KEY, skip_hub_health_test)
             else:
                 for hub in hubs:
@@ -92,21 +93,22 @@ def deploy(cluster_name, hub_name, skip_hub_health_test):
 
 def main():
     argparser = argparse.ArgumentParser()
-    subparsers = argparser.add_subparsers(dest='action')
+    subparsers = argparser.add_subparsers(dest="action")
 
-    build_parser = subparsers.add_parser('build')
-    deploy_parser = subparsers.add_parser('deploy')
+    build_parser = subparsers.add_parser("build")
+    deploy_parser = subparsers.add_parser("deploy")
 
-    deploy_parser.add_argument('cluster_name', nargs="?")
-    deploy_parser.add_argument('hub_name', nargs="?")
-    deploy_parser.add_argument('--skip-hub-health-test', action='store_true')
+    deploy_parser.add_argument("cluster_name", nargs="?")
+    deploy_parser.add_argument("hub_name", nargs="?")
+    deploy_parser.add_argument("--skip-hub-health-test", action="store_true")
 
     args = argparser.parse_args()
 
-    if args.action == 'build':
+    if args.action == "build":
         build()
-    elif args.action == 'deploy':
+    elif args.action == "deploy":
         deploy(args.cluster_name, args.hub_name, args.skip_hub_health_test)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -96,7 +96,7 @@ jupyterhub:
               values: [user-pool]
     image:
       name: set_automatically_by_automation
-      tag: 4066a62
+      tag: 638350c
     storage:
       type: static
       static:

--- a/hubs.yaml
+++ b/hubs.yaml
@@ -1,6 +1,5 @@
 clusters:
   - name: hackathon-alpha
-    image_repo:  "us-central1-docker.pkg.dev/two-eye-two-see/low-touch-hubs/base-user"
     provider: gcp
     gcp:
       key: secrets/hackathon-alpha.json


### PR DESCRIPTION
We were trying to build an image for all clusters - but
our hackathon-alpha cluster had the *wrong* image name set.
This caused our build script to use the wrong service account
to authenticate and build this image, failing. The error message
wasn't super informative either.

We now just don't build any user images for hackathon-alpha cluster,
since it uses a custom image anyway.

I also autoformat deploy.py while I'm at it.