### PR TITLE
Re-run flaky hub health test if needed

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-asyncio
 requests
 beautifulsoup4
+pytest-rerunfailures

--- a/tests/test_hub_health.py
+++ b/tests/test_hub_health.py
@@ -2,7 +2,9 @@ import os
 import pytest
 
 
+# Can be flaky due to image pull durations, let's re-run it once more if needed
 @pytest.mark.asyncio
+@pytest.mark.flaky(reruns=1)
 async def test_hub_healthy(hub, api_token):
     """
     Tests the hub is healthy.


### PR DESCRIPTION
The hub health check is often flaky, since new pod spinups
might require node spinups + image pulls. We just run the
test twice if needed, to make the deployment a little more
reliable.