### PR TITLE
Revert "Re-run flaky hub health test if needed"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,3 @@ pytest
 pytest-asyncio
 requests
 beautifulsoup4
-pytest-rerunfailures

--- a/tests/test_hub_health.py
+++ b/tests/test_hub_health.py
@@ -2,9 +2,7 @@ import os
 import pytest
 
 
-# Can be flaky due to image pull durations, let's re-run it once more if needed
 @pytest.mark.asyncio
-@pytest.mark.flaky(reruns=1)
 async def test_hub_healthy(hub, api_token):
     """
     Tests the hub is healthy.


### PR DESCRIPTION
Reverts 2i2c-org/pilot-hubs#322

Unfortunately, this does not work with async tests -
see https://github.com/pytest-dev/pytest-rerunfailures/issues/154
