### PR TITLE
Don't set defaultUrl in hubs.yaml

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -202,8 +202,6 @@ clusters:
                 funded_by:
                   name: 2i2c
                   url: https://2i2c.org
-            singleuser:
-              defaultUrl: /lab
             hub:
               config:
                 Authenticator:


### PR DESCRIPTION
This should be set in the congiruator instead, so
admins have control over it.