### PR TITLE
Specify configurator schema in deployment config

### DIFF
--- a/hub-templates/base-hub/Chart.yaml
+++ b/hub-templates/base-hub/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: base-hub
 # Let's keep this constant so other charts in this repo can depend on this easily
-version: 0.0.1-n534.h0a5b959
+version: 0.0.1-n569.hb296398
 dependencies:
   - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -127,6 +127,38 @@ jupyterhub:
             - port: 443
               protocol: TCP
   hub:
+    extraFiles:
+      configurator-schema-default:
+        mountPath: /usr/local/etc/jupyterhub-configurator/00-default.schema.json
+        data:
+          type: object
+          name: config
+          properties:
+            KubeSpawner.image:
+              type: string
+              title: User docker image
+              description: Determines languages, libraries and interfaces available
+              help: Leave this blank to use the default
+            Spawner.default_url:
+              type: string
+              title: Default User Interface
+              enum:
+                - "/tree"
+                - "/lab"
+                - "/rstudio"
+              default: "/tree"
+              enumMetadata:
+                interfaces:
+                  - value: "/tree"
+                    title: Classic Notebook
+                    description: What most people think of as Jupyter
+                  - value: "/lab"
+                    title: JupyterLab
+                    description: Powerful next generation notebook interface
+                  - value: "/rstudio"
+                    title: RStudio
+                    description: Very popular R IDE
+
     services:
       configurator:
         url: http://configurator:10101
@@ -134,9 +166,10 @@ jupyterhub:
           - python3
           - -m
           - jupyterhub_configurator.app
+          - --Configurator.config_file=/usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: '0.0.1-n534.h0a5b959'
+      tag: '0.0.1-n569.hb296398'
     config:
       JupyterHub:
         authenticator_class: oauthenticator.generic.GenericOAuthenticator

--- a/hub-templates/images/hub/Dockerfile
+++ b/hub-templates/images/hub/Dockerfile
@@ -2,6 +2,12 @@
 # If that changes, this should be changed too!
 FROM jupyterhub/k8s-hub:0.11.1-n298.hd9d7403b
 
-ENV CONFIGURATOR_VERSION 746e7285af40b9bafd227dae3f2e41d1a631a301
+ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configurator@${CONFIGURATOR_VERSION}
+
+USER root
+RUN mkdir -p /usr/local/etc/jupyterhub-configurator
+
+COPY jupyterhub_configurator_config.py /usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
+USER $NB_USER

--- a/hub-templates/images/hub/jupyterhub_configurator_config.py
+++ b/hub-templates/images/hub/jupyterhub_configurator_config.py
@@ -1,0 +1,16 @@
+import os
+from glob import glob
+import json
+
+
+CONFIGURATOR_BASE_PATH = "/usr/local/etc/jupyterhub-configurator"
+
+schema_files = sorted(glob(os.path.join(CONFIGURATOR_BASE_PATH, '*.schema.json')))
+
+schemas = {}
+
+for sf in schema_files:
+    with open(sf) as f:
+        schemas[sf] = json.load(f)
+
+c.Configurator.schemas = schemas


### PR DESCRIPTION
Configurator schema is likely to be specific to particular
deployments - although we should publish generic schemas
too. By moving it into config, we can iterate on this faster,
and have per-hub schemas too.

Ref #312 