### PR TITLE
Update Catalyst hub image

### DIFF
--- a/hubs.yaml
+++ b/hubs.yaml
@@ -355,8 +355,8 @@ clusters:
             jupyterhub:
               singleuser:
                 image:
-                  name: catalystcoop/pilot-hub
-                  tag: 2021.02.23
+                  name: catalystcoop/pudl-jupyter
+                  tag: 2021.03.27
                 memory:
                   limit: 6G
                   guarantee: 4G


### PR DESCRIPTION
Changed the name of the image (new repo on DockerHub) because we're using the same image for other PUDL Jupyter things now too.  Updated the version tag.