### PR TITLE
Fix missed rename

### DIFF
--- a/.github/workflows/deploy-paleohack.yaml
+++ b/.github/workflows/deploy-paleohack.yaml
@@ -20,4 +20,4 @@ jobs:
       - uses: mdgreenwald/mozilla-sops-action@v1
       - uses: ./.github/actions/deploy
         with:
-          cluster: 'hackathon-alpha'
+          cluster: 'paleohack'


### PR DESCRIPTION
hackathon-alpha was the project name when we thought we
might re-use it for other purposes - but now that the
hub is running constantly, it isn't being used like that.
It's just used for the paleohack hackathon.