### PR TITLE
Fix manual build of cluster images

### DIFF
--- a/deploy/__main__.py
+++ b/deploy/__main__.py
@@ -20,16 +20,17 @@ from utils import decrypt_file
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)
 
-def build():
+def build(cluster_name):
     """
-    Build and push all images for all clusters
+    Build and push the image for a given cluster
     """
-    config_file_path = Path(__file__).parent / "hubs.yaml"
-    clusters = parse_clusters(config_file_path)
-    for cluster in clusters:
-        if "image_repo" in cluster.spec:
-            with cluster.auth():
-                cluster.build_image()
+    config_file_path = Path(os.getcwd()) / "config/hubs" / f'{cluster_name}.cluster.yaml'
+    with open(config_file_path) as f:
+        cluster = Cluster(yaml.load(f))
+
+    if "image_repo" in cluster.spec:
+        with cluster.auth():
+            cluster.build_image()
 
 
 def deploy(cluster_name, hub_name, skip_hub_health_test, config_path):

--- a/deploy/__main__.py
+++ b/deploy/__main__.py
@@ -102,6 +102,8 @@ def main():
     deploy_parser = subparsers.add_parser("deploy")
     validate_parser = subparsers.add_parser("validate")
 
+    build_parser.add_argument("cluster_name")
+
     deploy_parser.add_argument("cluster_name")
     deploy_parser.add_argument("hub_name", nargs="?")
     deploy_parser.add_argument("--skip-hub-health-test", action="store_true")
@@ -111,9 +113,8 @@ def main():
 
     args = argparser.parse_args()
 
-
     if args.action == "build":
-        build()
+        build(args.cluster_name)
     elif args.action == "deploy":
         deploy(args.cluster_name, args.hub_name, args.skip_hub_health_test, args.config_path)
     elif args.action == 'validate':


### PR DESCRIPTION
This allows building the user image for a given cluster. Before the deploy script refactor, we could build the images for all the cluster.

Because the deploy can only happen now on a per-cluster basis, I though that the build should follow the same pattern.
@yuvipanda, what do you think? Build the image per cluster, or re-implement the old `parse_clusters` function and build for all clusters at once? 