### PR TITLE
Put GCP-only 'scratch bucket' behind a flag

### DIFF
--- a/hub-templates/daskhub/templates/env-vars.yaml
+++ b/hub-templates/daskhub/templates/env-vars.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.scratchBucket.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   scratch-bucket-name: {{ include "daskhub.scratchBucket.name" . }}
   scratch-bucket-protocol: "gcs"
+{{- end }}

--- a/hub-templates/daskhub/templates/service-account.yaml
+++ b/hub-templates/daskhub/templates/service-account.yaml
@@ -1,6 +1,7 @@
 {{- define "daskhub.serviceAccountName" -}}
 {{.Release.Name}}-user-sa
 {{- end }}
+{{ if .Values.scratchBucket.enabled }}
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
@@ -46,3 +47,4 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: {{ include "daskhub.serviceAccountName" .}}@{{ .Values.iam.projectId }}.iam.gserviceaccount.com
   name: user-sa
+{{- end }}

--- a/hub-templates/daskhub/templates/storage.yaml
+++ b/hub-templates/daskhub/templates/storage.yaml
@@ -1,6 +1,7 @@
 {{- define "daskhub.scratchBucket.name" -}}
 {{ .Values.iam.projectId }}-{{ .Release.Name }}-scratch-bucket
 {{- end }}
+{{ if .Values.scratchBucket.enabled }}
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
@@ -32,3 +33,4 @@ spec:
     apiVersion: storage.cnrm.cloud.google.com/v1beta1
     kind: StorageBucket
     name: {{ include "daskhub.scratchBucket.name" . }}
+{{- end }}

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -1,3 +1,10 @@
+scratchBucket:
+  # Enable a 'scratch' bucket per-hub, with read-write permissions for all
+  # users. This will set a `SCRATCH_BUCKET` env variable (and a PANGEO_SCRATCH variable
+  # too, for backwards compatibility). Users can share data with each other using
+  # this bucket.
+  enabled: true
+
 base-hub:
   # Copied from https://github.com/dask/helm-chart/blob/master/daskhub/values.yaml
   # FIXME: Properly use the upstream chart.
@@ -45,6 +52,7 @@ base-hub:
         # The default worker image matches the singleuser image.
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
 
+        # FIXME: Only set these if scratchBucket.enabled is true
         # Explicitly order environment variables that depend on each
         # other, since a environment variable needs to be defined first
         # before they can be interpolated.


### PR DESCRIPTION
Pangeo hubs have a `PANGEO_SCRATCH` env variable that
points to a GCS bucket, used to share data between users.
We implement that here too, but with a more generic `SCRATCH_BUCKET`
env var (`PANGEO_SCRATCH` is also set for backwards compat).
https://github.com/pangeo-data/pangeo-cloud-federation/issues/610
has some more info on the use cases for `PANGEO_SCRATCH`

Right now, we use Google Config Connector
(https://cloud.google.com/config-connector/docs/overview)
to set this up. We create Kubernetes CRDs, and the connector
creates appropriate cloud resources to match them. We use this
to provision a GCP Serivce account and a Storage bucket for each
hub.

Since these are GCP specific, running them on AWS fails. This
PR puts them behind a switch, so we can work on getting things to
AWS.

Eventually, it should also support AWS resources via the
AWS Service broker (https://aws.amazon.com/partners/servicebroker/)

Ref https://github.com/2i2c-org/pilot-hubs/issues/366