### PR TITLE
Fix imports in pytest

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -309,7 +309,7 @@ class Hub:
                     hub_url = f'https://{random.choice(domain)}'
 
                 exit_code = pytest.main([
-                    "-v", "deploy/tests",
+                    "-v", "deployer/tests",
                     "--hub-url", hub_url,
                     "--api-token", service_api_token,
                     "--hub-type", self.spec['template']

--- a/deployer/tests/conftest.py
+++ b/deployer/tests/conftest.py
@@ -1,8 +1,6 @@
 import pytest
 from pathlib import Path
 
-from .context import deploy
-
 def pytest_addoption(parser):
     """
     Define the commandline params that can be passed to pytest.

--- a/deployer/tests/context.py
+++ b/deployer/tests/context.py
@@ -3,4 +3,4 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import auth
-import deploy
+import deployer

--- a/deployer/tests/context.py
+++ b/deployer/tests/context.py
@@ -1,6 +1,0 @@
-import os
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import auth
-import deployer


### PR DESCRIPTION
Missed during earlier rename of deploy to deployer