### PR TITLE
Adding script to pull list of running hubs and display it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # helm charts
 hub/charts
 support/charts
+
+# Documentation build assets
+docs/tmp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,15 +68,14 @@ import pandas as pd
 from pathlib import Path
 
 # Grab the latest list of clusters defined in pilot-hubs/
-api = GhApi(token=os.environ.get("GITHUB_TOKEN"))
-clusters = api.repos.get_content("2i2c-org", "pilot-hubs", "config/hubs")
+clusters = Path("../config/hubs").glob("*")
 hub_list = []
 for cluster_info in clusters:
-    if "schema" in cluster_info['name']:
+    if "schema" in cluster_info.name:
         continue
     # For each cluster, grab it's YAML w/ the config for each hub
-    yaml = api.repos.get_content("2i2c-org", "pilot-hubs", cluster_info['path'])
-    cluster = safe_load(b64decode(yaml['content']).decode())
+    yaml = cluster_info.read_text()
+    cluster = safe_load(yaml)
 
     # For each hub in cluster, grab its metadata and add it to the list
     for hub in cluster['hubs']:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,6 @@ html_theme_options = {
 # Pull latest list of communities served by pilot-hubs/
 import requests
 from yaml import safe_load
-from ghapi.all import GhApi
-from base64 import b64decode
 import os
 import pandas as pd
 from pathlib import Path

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,5 +52,6 @@ Reference information about the pilot hubs.
 :caption: Reference
 :maxdepth: 2
 
+reference/hubs
 incidents/index
 ```

--- a/docs/reference/hubs.md
+++ b/docs/reference/hubs.md
@@ -1,0 +1,29 @@
+# List of running hubs
+
+Here's a list of running hubs.
+
+<div class="full-width">
+
+```{csv-table}
+:header-rows: 1
+:file: ../tmp/hub-table.csv
+```
+
+</div>
+
+
+
+<!-- DataTables to make the table above look nice -->
+<link rel="stylesheet"
+      href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css">
+<script type="text/javascript" 
+        src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+
+<script>
+$(document).ready( function () {
+    $('table').DataTable( {
+        "order": [[ 0, "template" ]],
+        "pageLength": 50
+    });
+} );
+</script>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,6 @@ myst-parser[sphinx,linkify]
 sphinx-book-theme
 sphinx-panels
 sphinx-autobuild
+pandas
+pyyaml
+requests


### PR DESCRIPTION
This ports over the code to generate a list of running hubs in this repository. It currently generates the table [in the team compass](https://team-compass.2i2c.org/en/latest/reference/hubs.html#running-jupyterhubs), but I think it'd be better to keep the code here. This way we know that the table is up-to-date, and also know if we change the config in a way that breaks the table. We also don't need authentication to grab the data from GitHub directly since the YAML files are already in this repository.

Here's the list of running hubs:

https://2i2c-pilot-hubs--376.org.readthedocs.build/en/376/reference/hubs.html