### PR TITLE
Remove 'nfs' spec from clusters yaml

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -6,8 +6,6 @@ gcp:
   project: two-eye-two-see
   cluster: low-touch-hubs-cluster
   zone: us-central1-b
-  nfs:
-    server: nfs-server-01
 hubs:
   - name: staging
     domain: staging.pilot.2i2c.cloud

--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -6,8 +6,6 @@ gcp:
   project: cb-1003-1696
   cluster: cloudbank-2i2c-cluster
   zone: us-central1-b
-  nfs:
-    server: nfs-server-01
 hubs:
   - name: spelman
     domain: spelman.cloudbank.2i2c.cloud

--- a/config/hubs/paleohack.cluster.yaml
+++ b/config/hubs/paleohack.cluster.yaml
@@ -5,8 +5,6 @@ gcp:
   project: hackathon-2i2c-project-alpha
   cluster: alpha-cluster
   zone: us-central1-b
-  nfs:
-    server: nfs-server-01
 hubs:
   - name: paleohack2021
     domain: paleohack2021.hackathon.2i2c.cloud

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -44,25 +44,11 @@ properties:
           If the cluster is a zonal cluster, this specifies the zone
           in which the cluster is. If it's a regional cluster, this
           specifies the region the cluster is in.
-      nfs:
-        type: object
-        description: |
-          Our home directories use NFS, and it is currently managed
-          outside the cluster. Helm needs to know the location of
-          the NFS server so it can use it for home directories.
-        properties:
-          server:
-            type: string
-            description: |
-              Name of NFS server
-        required:
-          - server
     required:
       - key
       - project
       - cluster
       - zone
-      - nfs
   hubs:
     type: array
     description: |


### PR DESCRIPTION
We aren't actually using this anywhere! If we want
to override NFS servers, we should do that in
jupyterhub.nfsPVC