### PR TITLE
Require trailing slash in baseSharePath

### DIFF
--- a/hub-templates/base-hub/templates/nfs-pvc.yaml
+++ b/hub-templates/base-hub/templates/nfs-pvc.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteMany
   nfs:
     server: {{ .Values.nfsPVC.nfs.serverIP | quote}}
-    path: "{{ .Values.nfsPVC.nfs.baseShareName }}/{{ .Release.Name }}"
+    path: "{{ .Values.nfsPVC.nfs.baseShareName }}{{ .Release.Name }}"
   mountOptions:
     - soft
     - noatime

--- a/hub-templates/base-hub/templates/nfs-share-creater.yaml
+++ b/hub-templates/base-hub/templates/nfs-share-creater.yaml
@@ -27,7 +27,7 @@ spec:
           image: busybox
           env:
             - name: NFS_SHARE_NAME
-              value: "{{ .Values.nfsPVC.nfs.baseShareName }}/{{ .Release.Name }}"
+              value: "{{ .Values.nfsPVC.nfs.baseShareName }}{{ .Release.Name }}"
           command:
             - /bin/sh
             - -c

--- a/hub-templates/base-hub/values.yaml
+++ b/hub-templates/base-hub/values.yaml
@@ -18,7 +18,8 @@ nfsPVC:
   enabled: true
   nfs:
     serverIP: nfs-server-01
-    baseShareName: /export/home-01/homes
+    # MUST HAVE TRAILING SLASH
+    baseShareName: /export/home-01/homes/
 
 jupyterhub:
   ingress:


### PR DESCRIPTION
In places like EFS, the base path is `/` - and right now
there's no way to actually specify that!