### PR TITLE
Generate carbonplan kops file with jsonnet

### DIFF
--- a/kops/carbonplan.jsonnet
+++ b/kops/carbonplan.jsonnet
@@ -1,0 +1,71 @@
+local cluster = import "./libsonnet/cluster.jsonnet";
+local ig = import "./libsonnet/instancegroup.jsonnet";
+
+local zone = "us-east-1a";
+local nodes = [
+    {spec+: {
+        machineType: "m4.xlarge"
+    }},
+    {spec+: {
+        machineType: "m4.2xlarge",
+        maxSize: 20
+    }},
+];
+
+local data = {
+    cluster: cluster {
+        metadata+: {
+            name: "farallon.k8s.local"
+        },
+        spec+: {
+            configBase: "hi"
+        },
+        _config+:: {
+            zone: zone,
+            masterInstanceGroupName: data.master.metadata.name
+        }
+    },
+    master: ig {
+        metadata+: {
+            labels+: {
+                "kops.k8s.io/cluster": data.cluster.metadata.name
+            },
+            name: "master"
+        },
+        spec+: {
+            machineType: "t3.medium",
+            subnets: [zone],
+            maxSize: 3,
+            role: "Master"
+        },
+    },
+    nodes: [
+        ig {
+            local thisIg = self,
+            metadata+: {
+                labels+: {
+                    "kops.k8s.io/cluster": data.cluster.metadata.name
+                },
+                name: "notebook-%s" % std.strReplace(thisIg.spec.machineType, ".", "-")
+            },
+            spec+: {
+                machineType: n.machineType,
+                subnets: [zone],
+                maxSize: 3,
+                role: "Node",
+                nodeLabels+: {
+                    "hub.jupyter.org/pool-name": thisIg.metadata.name
+                },
+                taints: [
+                    "hub.jupyter.org_dedicated=user:NoSchedule",
+                    "hub.jupyter.org/dedicated=user:NoSchedule"
+                ],
+            },
+        } + n for n in nodes
+    ]
+};
+
+[
+    data.cluster,
+    data.master
+] + data.nodes

--- a/kops/libsonnet/cluster.jsonnet
+++ b/kops/libsonnet/cluster.jsonnet
@@ -1,0 +1,107 @@
+// local cluster(name, configBase, zone, masterIgName, networkCIDR, subnets) = {
+{
+    _config+:: {
+        masterInstanceGroupName: "",
+        zone: "",
+    },
+    apiVersion: "kops.k8s.io/v1alpha2",
+    kind: "Cluster",
+    metadata: {
+        name: ""
+    },
+    spec: {
+        clusterAutoscaler: {
+            enabled: true
+        },
+        api: {
+            loadBalancer: {
+                class: "Classic",
+                type: "Public"
+            }
+        },
+        authorization: {
+            rbac: {}
+        },
+        dns: {
+            kubeDNS: {
+                provider: "CoreDNS"
+            }
+        },
+        channel: "stable",
+        cloudProvider: "aws",
+        configBase: "",
+        containerRuntime: "docker",
+        etcdClusters: [
+            {
+                cpuRequest: "200m",
+                etcdMembers: [
+                    {
+                        instanceGroup: $._config.masterInstanceGroupName,
+                        name: "a"
+                    }
+                ],
+                memoryRequest: "100Mi",
+                name: "main"
+            },
+            {
+                cpuRequest: "100m",
+                etcdMembers: [
+                    {
+                        instanceGroup: $._config.masterInstanceGroupName,
+                        name: "a"
+                    }
+                ],
+                memoryRequest: "100Mi",
+                name: "events"
+            }
+        ],
+        iam: {
+            allowContainerRegistry: true,
+            legacy: false
+        },
+        kubelet: {
+            anonymousAuth: false,
+            featureGates: {
+                // These boolean values need to be strings
+                LegacyNodeRoleBehavior: "false",
+                ServiceNodeExclusion: "false"
+            }
+        },
+        kubeControllerManager: {
+            featureGates: {
+                // These boolean values need to be strings
+                LegacyNodeRoleBehavior: "false",
+                ServiceNodeExclusion: "false"
+            }
+        },
+        kubernetesApiAccess: [
+            // Allow access to the master API from everywhere
+            "0.0.0.0/0"
+        ],
+        kubernetesVersion: "1.19.7",
+        masterPublicName: "api.%s" % $.metadata.name,
+        networkCIDR: "172.20.0.0/16",
+        networking: {
+            calico: {
+                majorVersion: "v3"
+            }
+        },
+        nonMasqueradeCIDR: "100.64.0.0/10",
+        sshAccess: [
+            "0.0.0.0/0"
+        ],
+        subnets: [{
+            cidr: "172.20.32.0/19",
+            name: $._config.zone,
+            type: "Public",
+            zone: $._config.zone
+        }],
+        topology: {
+            dns: {
+                type: "Public"
+            },
+            masters: "public",
+            nodes: "public"
+        }
+    }
+}

--- a/kops/libsonnet/instancegroup.jsonnet
+++ b/kops/libsonnet/instancegroup.jsonnet
@@ -1,0 +1,38 @@
+
+local makeCloudLabels(labels) = {
+        ["k8s.io/cluster-autoscaler/node-template/label/%s" % key]: labels[key]
+        for key in std.objectFields(labels)
+};
+// Kops expects these as strings of form Key=Value:Effect in spec.taints,
+// but cloudlabels expects them to be key value pairs of Key: Value:Effect
+local makeCloudTaints(taints) = {
+    ["k8s.io/cluster-autoscaler/node-template/taint/%s" % splits[0]]: splits[1]
+    for splits in [std.split(t, '=') for t in taints]
+};
+
+
+// local instanceGroup(name, clusterName, nodeImage, labels, taints, machineType, subnets, minSize, maxSize, role) = {
+{
+    _config+:: {
+        clusterName: ""
+    },
+    apiVersion: "kops.k8s.io/v1alpha2",
+    kind: "InstanceGroup",
+    metadata: {
+        labels+: {
+            "kops.k8s.io/cluster": $._config.clusterName,
+        },
+        name: ""
+    },
+    spec: {
+        image: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1",
+        cloudLabels: makeCloudLabels(self.nodeLabels) + makeCloudTaints(self.taints),
+        taints: [],
+        nodeLabels: {},
+        machineType: "",
+        maxSize: 20,
+        minSize: 0,
+        role: "Master",
+        subnets: [],
+    }
+}


### PR DESCRIPTION
Each kops cluster we want to deploy will have some things in
common, but many differences. 2i2c engineers should be able to
create and manage these without a lot of cognitive overhead.

1. All clusters should have some basic opinionated defaults
2. But everything should be customizable as necessary
3. kops configuration is already declerative, and we should
   *not* add another layer on top.

jsonnet helps with this. It's a powerful declarative language
generating JSON, with conditionals, prototype inheritance,
deep merging, maps, etc.

In this PR, we create two base objects that can be customized -
a `cluster` object that generates a kops Cluster object,
and a `instancegroup` object that generates a kops InstanceGroup
object. We use these to generate our kops config for
carbonplan.jsonnet. jsonnet is only used for some abstraction
and deep merging - there isn't an extra level of abstraction
here.