### PR TITLE
Set proxy.https.hosts by default too

### DIFF
--- a/config/hubs/farallon.cluster.yaml
+++ b/config/hubs/farallon.cluster.yaml
@@ -94,8 +94,6 @@ hubs:
               type: LoadBalancer
             https:
               enabled: true
-              hosts:
-              - staging.farallon.2i2c.cloud 
             chp:
               nodeSelector: {}
               tolerations:

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -111,7 +111,12 @@ class Hub:
 
         generated_config = {
             'jupyterhub': {
-                'proxy': { 'secretToken': proxy_secret },
+                'proxy': {
+                    'secretToken': proxy_secret,
+                    'https': {
+                        'hosts': self.spec['domain'] if isinstance(self.spec['domain'], list) else [self.spec['domain']]
+                    }
+                },
                 'ingress': {
                     'hosts': self.spec['domain'] if isinstance(self.spec['domain'], list) else [self.spec['domain']],
                     'tls': [

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -66,6 +66,8 @@ jupyterhub:
     hook:
       enabled: false
   proxy:
+    https:
+      enabled: false
     service:
       type: ClusterIP
     chp:


### PR DESCRIPTION
In some hubs, we currently just use a loadbalancer + autohttps
to get traffic into the cluster. This is simpler than getting
nginx-ingress + certmanager setup, although not entirely
sure if that's the right thing to do long term.

By putting the domains in proxy.https.hosts as well, we can
decide to use or not use autohttps on a per-hub basis, without
having to repeat the domains in multiple places. Staging and
prod hubs that have the exact same config but differ in
domains can be easily constructed thus.