### PR TITLE
Normalize node labeling in GKE & upgrade version

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -123,14 +123,19 @@ module "gke" {
     all = {}
 
     core-pool = {
-      default-node-pool = true
-      "hub.jupyter.org/pool-name" = "core-pool"
+      default-node-pool              = true
+      "hub.jupyter.org/pool-name"    = "core-pool",
+      "hub.jupyter.org/node-purpose" = "core",
+      "k8s.dask.org/node-purpose"    = "core"
     }
     user-pool = {
-      "hub.jupyter.org/pool-name" = "user-pool"
+      "hub.jupyter.org/pool-name"    = "user-pool"
+      "hub.jupyter.org/node-purpose" = "user",
+      "k8s.dask.org/node-purpose"    = "scheduler"
     }
     dask-worker-pool = {
       "hub.jupyter.org/pool-name" = "dask-worker-pool"
+      "k8s.dask.org/node-purpose" = "worker"
     }
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,7 +56,9 @@ module "gke" {
   horizontal_pod_autoscaling = false
   network_policy             = true
   # We explicitly set up a core pool, so don't need the default
-  remove_default_node_pool   = true
+  remove_default_node_pool = true
+  kubernetes_version       = "1.19.9-gke.1400"
+
 
   node_pools = [
     {
@@ -73,7 +75,7 @@ module "gke" {
       preemptible        = false
       initial_node_count = 1
       # Let's pin this so we don't upgrade each time terraform runs
-      version            = "1.17.12-gke.2502"
+      version = "1.19.9-gke.1400"
     },
     {
       name               = "user-pool"
@@ -107,7 +109,7 @@ module "gke" {
       preemptible        = true
       initial_node_count = 0
       # Let's pin this so we don't upgrade each time terraform runs
-      version            = "1.17.12-gke.2502"
+      version = "1.19.9-gke.1400"
     },
   ]
 


### PR DESCRIPTION
With
https://github.com/2i2c-org/pilot-hubs/pull/391/commits/3c344a4c6a52cb670ea1856dc60714d3082b79ee,
we're trying to normalize labels in our clusters. Primarily,
we want to have three sets of labels that can be composed as
needed.

1. What components of a JupyterHub can run here? core / user
2. What components of a dask gateway can run here? core / scheduler /
   worker
3. What are the features of the node pool we care about? For example,
   if we want to be on an r5.xlarge node, we should target the
   existing node.kubernetes.io/instance-type label

This gives us flexibility without adding too much overhead.

https://github.com/2i2c-org/pilot-hubs/pull/391 changes the base hub
template to use these new labels. We should change our GKE clusters to
have these labels too before we can deploy that PR. This PR adds
these labels in addition to the existing labels, to avoid any
disruption

Since these changes require deleting & recreating the node pools anyway,
might as well use this opportunity to upgrade k8s version too.