### PR TITLE
pilot-hubs repo no longer has a gh-master branch

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -15,8 +15,8 @@ hubs:
     config:
       docs_service:
         enabled: true
-        repo: https://github.com/2i2c-org/pilot-hubs
-        branch: gh-pages
+        repo: https://github.com/jupyterhub/nbgitpuller
+        branch: master
       jupyterhub:
         homepage:
           templateVars:


### PR DESCRIPTION
Builds are now served from RTD rather than GitHub pages,
so there's no gh-pages branch to pull. nbgitpuller repo
does, so let's use that for now.

This causes current deployments to fail.