### PR TITLE
Change core node type

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,7 +25,7 @@ variable "regional_cluster" {
 
 variable "core_node_machine_type" {
   type    = string
-  default = "e2-highcpu-4"
+  default = "n1-highmem-4"
 }
 
 variable "core_node_max_count" {


### PR DESCRIPTION
This ends up creating 4 core nodes to handle everything,
since our memory requests are much more than our CPU requests.

Changing the node type helps cut it down, and then we can
adjust our memory requests later when needed