### PR TITLE
Use gh-pages branch of nbgitpuller

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -16,7 +16,7 @@ hubs:
       docs_service:
         enabled: true
         repo: https://github.com/jupyterhub/nbgitpuller
-        branch: master
+        branch: gh-pages
       jupyterhub:
         homepage:
           templateVars:


### PR DESCRIPTION
Docs are rendered and pushed there.
Follow-up to https://github.com/2i2c-org/pilot-hubs/pull/401