### PR TITLE
Add flake8 checker action + fix flakes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,11 +5,10 @@
 # C: complexity
 # F403: import *
 # F811: redefinition of unused `name` from line `N`
-# F841: local variable assigned but never used
 # E402: module level import not at top of file
 # I100: Import statements are in the wrong order
 # I101: Imported names are in the wrong order. Should be
-ignore = E, C, W, F403, F811, F841, E402, I100, I101, D400
+ignore = E, C, W, F403, F811, E402, I100, I101, D400
 builtins = c, get_config
 exclude =
     .cache,

--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,6 @@
 # I100: Import statements are in the wrong order
 # I101: Imported names are in the wrong order. Should be
 ignore = E, C, W, F403, F811, E402, I100, I101, D400
-builtins = c, get_config
 exclude =
     .cache,
     .github

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+# Ignore style and complexity
+# E: style errors
+# W: style warnings
+# C: complexity
+# F403: import *
+# F811: redefinition of unused `name` from line `N`
+# F841: local variable assigned but never used
+# E402: module level import not at top of file
+# I100: Import statements are in the wrong order
+# I101: Imported names are in the wrong order. Should be
+ignore = E, C, W, F403, F811, F841, E402, I100, I101, D400
+builtins = c, get_config
+exclude =
+    .cache,
+    .github

--- a/.flake8
+++ b/.flake8
@@ -3,12 +3,10 @@
 # E: style errors
 # W: style warnings
 # C: complexity
-# F403: import *
-# F811: redefinition of unused `name` from line `N`
 # E402: module level import not at top of file
 # I100: Import statements are in the wrong order
 # I101: Imported names are in the wrong order. Should be
-ignore = E, C, W, F403, F811, E402, I100, I101, D400
+ignore = E, C, W, E402, I100, I101, D400
 exclude =
     .cache,
     .github

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -1,0 +1,21 @@
+name: Python lint
+
+on:
+  push:
+    paths:
+      - deployer/
+
+jobs:
+  flake8_py3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        run: |
+          flake8 deployer/

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install flake8

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -18,4 +18,4 @@ jobs:
         run: pip install flake8
       - name: Run flake8
         run: |
-          flake8 deployer/
+          flake8 deployer/ docs/

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -1,20 +1,16 @@
 """
 Deploy many JupyterHubs to many Kubernetes Clusters
 """
-import sys
-import tempfile
-from pathlib import Path
-from ruamel.yaml import YAML
-import subprocess
-import hashlib
-import hmac
-import os
 import argparse
-import asyncio
+import os
+import sys
+from pathlib import Path
+
 import jsonschema
+from ruamel.yaml import YAML
 
 from auth import KeyProvider
-from hub import Hub, Cluster
+from hub import Cluster
 from utils import decrypt_file
 
 # Without `pure=True`, I get an exception about str / byte issues
@@ -84,7 +80,7 @@ def deploy(cluster_name, hub_name, skip_hub_health_test, config_path):
 
 
 def validate(cluster_name):
-    cluster_dir = Path(os.getcwd()) / "config/hubs" 
+    cluster_dir = Path(os.getcwd()) / "config/hubs"
     schema_file = cluster_dir / "schema.yaml"
     config_file = cluster_dir / f"{cluster_name}.cluster.yaml"
     with open(config_file) as cf, open(schema_file) as sf:

--- a/deployer/auth.py
+++ b/deployer/auth.py
@@ -1,7 +1,5 @@
-import requests
-from auth0.v3.management import Auth0
 from auth0.v3.authentication import GetToken
-import os
+from auth0.v3.management import Auth0
 
 # What key in the authenticated user's profile to use as hub username
 # This shouldn't be changeable by the user!
@@ -104,16 +102,16 @@ class KeyProvider:
                 if client_id in enabled_clients:
                     enabled_clients.remove(client_id)
                     needs_update = True
-            
+
             if needs_update:
                 self.auth0.connections.update(
                     connection['id'],
                     {'enabled_clients': enabled_clients}
                 )
-        
+
         return client
 
-        
+
     def get_client_creds(self, client, connection_name):
         """
         Return z2jh config for auth0 authentication for this JupyterHub

--- a/deployer/build.py
+++ b/deployer/build.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import subprocess
 

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -1,20 +1,17 @@
-import backoff
-from copy import deepcopy
 import hashlib
-import subprocess
 import hmac
-import os
 import json
-import pytest
+import os
 import random
+import subprocess
 import tempfile
-from ruamel.yaml import YAML
-from ruamel.yaml.scanner import ScannerError
-from textwrap import dedent
-from build import last_modified_commit
-from build import build_image
 from contextlib import contextmanager
-from jhub_client.execute import execute_notebook, JupyterHubAPI
+from textwrap import dedent
+
+import pytest
+from ruamel.yaml import YAML
+
+from build import build_image
 from utils import decrypt_file
 
 # Without `pure=True`, I get an exception about str / byte issues
@@ -43,7 +40,7 @@ class Cluster:
             yield from self.auth_kubeconfig()
         else:
             raise ValueError(f'Provider {self.spec["provider"]} not supported')
-            
+
 
     def auth_kubeconfig(self):
         """
@@ -115,7 +112,7 @@ class Hub:
                     'hosts': self.spec['domain'] if isinstance(self.spec['domain'], list) else [self.spec['domain']],
                     'tls': [
                         {
-                            'secretName': f'https-auto-tls',
+                            'secretName': 'https-auto-tls',
                             'hosts': self.spec['domain'] if isinstance(self.spec['domain'], list) else [self.spec['domain']]
                         }
                     ]

--- a/deployer/tests/conftest.py
+++ b/deployer/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 
 def pytest_addoption(parser):
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,9 +59,7 @@ html_theme_options = {
 
 # -- Custom scripts -----------------------------------------
 # Pull latest list of communities served by pilot-hubs/
-import requests
 from yaml import safe_load
-import os
 import pandas as pd
 from pathlib import Path
 
@@ -89,7 +87,7 @@ for cluster_info in clusters:
 
         hub_list.append({
             'name': hub_config['homepage']['templateVars']['org']['name'],
-            'domain': f"[{hub['domain']}](https://{hub['domain']})",  
+            'domain': f"[{hub['domain']}](https://{hub['domain']})",
             "id": hub['name'],
             "template": hub['template'],
         })


### PR DESCRIPTION
- Copied .flake8 file from upstream JupyterHub, but removed
  the ignore for unused module imports and local variables
- Fix flake8 warnings
- Setup a github action for the lint

- Turn on flake8 warning for unused local variable
  and fix bug found due to this!

  Don't overwrite user's KUBECONFIG

  Without this, your local authentication with kubectl
  is reset to that of the serviceaccount used to deploy the
  cluster. If you try and switch cluster, it'll fail with
  strange errors.

  Now we properly set the env vars while authenticated so
  it does not leak out.

  Found because I turned on flake8 warning for unused
  local variables!