### PR TITLE
Move cloudResources under jupyterhub.custom

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -50,12 +50,13 @@ hubs:
     config:
       basehub:
         jupyterhub:
-          cloudResources:
-            provider: gcp
-            gcp:
-              projectId: two-eye-two-see
-            scratchBucket:
-              enabled: true
+          custom:
+            cloudResources:
+              provider: gcp
+              gcp:
+                projectId: two-eye-two-see
+              scratchBucket:
+                enabled: true
           homepage:
             templateVars:
               org:
@@ -224,12 +225,13 @@ hubs:
     config:
       basehub:
         jupyterhub:
-          cloudResources:
-            provider: gcp
-            gcp:
-              projectId: two-eye-two-see
-            scratchBucket:
-              enabled: true
+          custom:
+            cloudResources:
+              provider: gcp
+              gcp:
+                projectId: two-eye-two-see
+              scratchBucket:
+                enabled: true
           singleuser:
             image:
               name: catalystcoop/pudl-jupyter
@@ -302,12 +304,13 @@ hubs:
     config:
       basehub:
         jupyterhub:
-          cloudResources:
-            provider: gcp
-            gcp:
-              projectId: two-eye-two-see
-            scratchBucket:
-              enabled: true
+          custom:
+            cloudResources:
+              provider: gcp
+              gcp:
+                projectId: two-eye-two-see
+              scratchBucket:
+                enabled: true
           singleuser:
             image:
               name: pangeo/pangeo-notebook

--- a/hub-templates/basehub/templates/cloud-resources/gcp/_helpers.tpl
+++ b/hub-templates/basehub/templates/cloud-resources/gcp/_helpers.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 
 {{- define "cloudResources.scratchBucket.name" -}}
-{{- if eq .Values.jupyterhub.cloudResources.provider "gcp" -}}
-{{ .Values.jupyterhub.cloudResources.gcp.projectId }}-{{ .Release.Name }}-scratch-bucket
+{{- if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" -}}
+{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}-{{ .Release.Name }}-scratch-bucket
 {{- end -}}
 {{- end }}

--- a/hub-templates/basehub/templates/cloud-resources/gcp/service-account.yaml
+++ b/hub-templates/basehub/templates/cloud-resources/gcp/service-account.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.jupyterhub.cloudResources.scratchBucket.enabled}}
+{{ if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled}}
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
   name: {{ include "cloudResources.gcp.serviceAccountName" . }}
   annotations:
-    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.cloudResources.gcp.projectId | quote }}
+    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.custom.cloudResources.gcp.projectId | quote }}
 spec:
   displayName: {{ .Release.Name }} hub user service account
 ---
@@ -13,7 +13,7 @@ kind: IAMPolicy
 metadata:
   name: workload-identity-binding
   annotations:
-    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.cloudResources.gcp.projectId | quote }}
+    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.custom.cloudResources.gcp.projectId | quote }}
 spec:
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -22,19 +22,19 @@ spec:
   bindings:
     - role: roles/iam.workloadIdentityUser
       members:
-        - serviceAccount:{{ .Values.jupyterhub.cloudResources.gcp.projectId }}.svc.id.goog[{{ .Release.Namespace }}/user-sa]
+        - serviceAccount:{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}.svc.id.goog[{{ .Release.Namespace }}/user-sa]
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: sa-requester-pays-binding
   annotations:
-    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.cloudResources.gcp.projectId | quote }}
+    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.custom.cloudResources.gcp.projectId | quote }}
 spec:
-  member: serviceAccount:{{ include "cloudResources.gcp.serviceAccountName" . }}@{{ .Values.jupyterhub.cloudResources.gcp.projectId }}.iam.gserviceaccount.com
+  member: serviceAccount:{{ include "cloudResources.gcp.serviceAccountName" . }}@{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}.iam.gserviceaccount.com
   role: roles/serviceusage.serviceUsageConsumer
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    external: projects/{{ .Values.jupyterhub.cloudResources.gcp.projectId }}
+    external: projects/{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}
 {{- end }}

--- a/hub-templates/basehub/templates/cloud-resources/gcp/storage-bucket.yaml
+++ b/hub-templates/basehub/templates/cloud-resources/gcp/storage-bucket.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.jupyterhub.cloudResources.scratchBucket.enabled  }}
-{{ if eq .Values.jupyterhub.cloudResources.provider "gcp" }}
+{{ if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled  }}
+{{ if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" }}
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
   annotations:
-    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.cloudResources.gcp.projectId | quote }}
+    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.custom.cloudResources.gcp.projectId | quote }}
     cnrm.cloud.google.com/force-destroy: "false"
   name: {{ include "cloudResources.scratchBucket.name" . }}
 spec:
@@ -20,9 +20,9 @@ kind: IAMPolicyMember
 metadata:
   name: scratch-bucket-binding
   annotations:
-    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.cloudResources.gcp.projectId | quote }}
+    cnrm.cloud.google.com/project-id : {{ .Values.jupyterhub.custom.cloudResources.gcp.projectId | quote }}
 spec:
-  member: serviceAccount:{{ include "cloudResources.gcp.serviceAccountName" . }}@{{ .Values.jupyterhub.cloudResources.gcp.projectId}}.iam.gserviceaccount.com
+  member: serviceAccount:{{ include "cloudResources.gcp.serviceAccountName" . }}@{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId}}.iam.gserviceaccount.com
   # This gives users the ability to delete the bucket too :(
   # But without this, I think you can't list objects in the bucket
   role: roles/storage.admin

--- a/hub-templates/basehub/templates/user-sa.yaml
+++ b/hub-templates/basehub/templates/user-sa.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    {{ if .Values.jupyterhub.cloudResources.scratchBucket.enabled}}
-    {{ if eq .Values.jupyterhub.cloudResources.provider "gcp" }}
-    iam.gke.io/gcp-service-account: {{ include "cloudResources.gcp.serviceAccountName" .}}@{{ .Values.jupyterhub.cloudResources.gcp.projectId }}.iam.gserviceaccount.com
+    {{ if .Values.jupyterhub.custom.cloudResources.scratchBucket.enabled}}
+    {{ if eq .Values.jupyterhub.custom.cloudResources.provider "gcp" }}
+    iam.gke.io/gcp-service-account: {{ include "cloudResources.gcp.serviceAccountName" .}}@{{ .Values.jupyterhub.custom.cloudResources.gcp.projectId }}.iam.gserviceaccount.com
     {{- end }}
     {{- end }}
   name: user-sa

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -28,12 +28,13 @@ nfsPVC:
     baseShareName: /export/home-01/homes/
 
 jupyterhub:
-  cloudResources:
-    provider: null
-    gcp:
-      projectId: null
-    scratchBucket:
-      enabled: false
+  custom:
+    cloudResources:
+      provider: null
+      gcp:
+        projectId: null
+      scratchBucket:
+        enabled: false
   ingress:
     enabled: true
     annotations:
@@ -287,3 +288,28 @@ jupyterhub:
             return resp
 
         c.JupyterHub.authenticator_class = CustomOAuthenticator
+
+      07-cloud-storage-bucket: |
+        from z2jh import get_config
+        cloud_resources = get_config('custom.cloudResources')
+        scratch_bucket = cloud_resources['scratchBucket']
+        import os
+
+        if scratch_bucket['enabled']:
+          # FIXME: Support other providers too
+          assert cloud_resources['provider'] == 'gcp'
+          project_id = cloud_resources['gcp']['projectId']
+
+          release = os.environ['HELM_RELEASE_NAME']
+          bucket_protocol = 'gcs'
+          bucket_name = f'{project_id}-{release}-scratch-bucket'
+          env = {
+            'SCRATCH_BUCKET_PROTOCOL': bucket_protocol,
+            # Matches "daskhub.scratchBUcket.name" helm template
+            'SCRATCH_BUCKET_NAME': bucket_name,
+            # Use k8s syntax of $(ENV_VAR) to substitute env vars dynamically in other env vars
+            'SCRATCH_BUCKET': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
+            'PANGEO_SCRATCH': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
+          }
+
+          c.KubeSpawner.environment.update(env)

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -92,30 +92,6 @@ basehub:
                   break
           else:
               print("dask-gateway service not found. Did you set jupyterhub.hub.services.dask-gateway.apiToken?")
-        daskhub-02-cloud-storage-bucket: |
-          from z2jh import get_config
-          cloud_resources = get_config('cloudResources')
-          scratch_bucket = cloud_resources['scratchBucket']
-          import os
-
-          if scratch_bucket['enabled']:
-            # FIXME: Support other providers too
-            assert cloud_resources['provider'] == 'gcp'
-            project_id = cloud_resources['gcp']['projectId']
-
-            release = os.environ['HELM_RELEASE_NAME']
-            bucket_protocol = 'gcs'
-            bucket_name = f'{project_id}-{release}-scratch-bucket'
-            env = {
-              'SCRATCH_BUCKET_PROTOCOL': bucket_protocol,
-              # Matches "daskhub.scratchBUcket.name" helm template
-              'SCRATCH_BUCKET_NAME': bucket_name,
-              # Use k8s syntax of $(ENV_VAR) to substitute env vars dynamically in other env vars
-              'SCRATCH_BUCKET': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
-              'PANGEO_SCRATCH': f'{bucket_protocol}://{bucket_name}/$(JUPYTERHUB_USER)',
-            }
-
-            c.KubeSpawner.environment.update(env)
 
 dask-gateway:
   enabled: true  # Enabling dask-gateway will install Dask Gateway as a dependency.


### PR DESCRIPTION
With hhttps://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2200,
helm will default to not allowing arbitrary extra properties anywher
except under jupyterhub.custom. This helps us move towards 1.0

Ref https://github.com/2i2c-org/pilot-hubs/issues/414