### PR TITLE
Fix image build script + upgrade otter

### DIFF
--- a/deployer/build.py
+++ b/deployer/build.py
@@ -51,11 +51,12 @@ def image_exists(image_name):
 
     return result.returncode == 0
 
+
 def build_image(image_repo):
     """
     Build & push image in images/user if needed
     """
-    tag = last_modified_commit(os.path.join(HERE, "images/user"))
+    tag = last_modified_commit(os.path.join(HERE, "../images/user"))
     image_name = f"{image_repo}:{tag}"
 
     if image_exists(image_name):

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -70,10 +70,11 @@ class Cluster:
                 config = {}
 
             helpers = config.get('credHelpers', {})
-            helpers[registry] = helper
-            config['credHelpers'] = helpers
-            with open(dockercfg_path, 'w') as f:
-                json.dump(config, f)
+            if helpers.get(registry) != helper:
+                helpers[registry] = helper
+                config['credHelpers'] = helpers
+                with open(dockercfg_path, 'w') as f:
+                    json.dump(config, f, indent=4)
 
 
     def auth_kubeconfig(self):

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -106,7 +106,7 @@ jupyterhub:
       hub.jupyter.org/node-purpose: user
     image:
       name: set_automatically_by_automation
-      tag: 1b83c4f
+      tag: 524cf58
     storage:
       type: static
       static:

--- a/images/user/environment.yml
+++ b/images/user/environment.yml
@@ -44,7 +44,7 @@ dependencies:
     - jupyter-rsession-proxy==1.2
     - jupyter-tree-download==1.0.1
     - ipywidgets==7.5.1
-    - otter-grader==1.1.3
+    - otter-grader==2.1.7
 
     - datascience
     - geojson


### PR DESCRIPTION
- Fix deployer build setup so builds & pushes actually work
- Authenticate to docker by setting up appropriate credential
   helper. Currently supports google artifact registry only, since
   that's the only thing we use this piece of code for.
    
   https://docs.docker.com/engine/reference/commandline/login/#credential-helpers
   has more information
- Upgrade version of otter

Fixes https://github.com/2i2c-org/pilot/issues/71