### PR TITLE
Allow setting env vars for dask workers

### DIFF
--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -140,37 +140,6 @@ hubs:
               effect: "NoSchedule"
             # TODO: figure out a replacement for userLimits.
           extraConfig:
-            optionHandler: |
-              from dask_gateway_server.options import Options, Integer, Float, String
-              def cluster_options(user):
-                def option_handler(options):
-                    if ":" not in options.image:
-                        raise ValueError("When specifying an image you must also provide a tag")
-                    extra_annotations = {
-                        "hub.jupyter.org/username": user.name,
-                        "prometheus.io/scrape": "true",
-                        "prometheus.io/port": "8787",
-                    }
-                    extra_labels = {
-                        "hub.jupyter.org/username": user.name,
-                    }
-                    return {
-                        "worker_cores_limit": options.worker_cores,
-                        "worker_cores": min(options.worker_cores / 2, 1),
-                        "worker_memory": "%fG" % options.worker_memory,
-                        "image": options.image,
-                        "scheduler_extra_pod_annotations": extra_annotations,
-                        "worker_extra_pod_annotations": extra_annotations,
-                        "scheduler_extra_pod_labels": extra_labels,
-                        "worker_extra_pod_labels": extra_labels,
-                    }
-                return Options(
-                    Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
-                    Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
-                    String("image", default="carbonplan/trace-python-notebook:latest", label="Image"),
-                    handler=option_handler,
-                )
-              c.Backend.cluster_options = cluster_options
             idle: |
               # timeout after 30 minutes of inactivity
               c.KubeClusterConfig.idle_timeout = 1800

--- a/config/hubs/openscapes.cluster.yaml
+++ b/config/hubs/openscapes.cluster.yaml
@@ -142,37 +142,6 @@ hubs:
               effect: "NoSchedule"
             # TODO: figure out a replacement for userLimits.
           extraConfig:
-            optionHandler: |
-              from dask_gateway_server.options import Options, Integer, Float, String
-              def cluster_options(user):
-                def option_handler(options):
-                    if ":" not in options.image:
-                        raise ValueError("When specifying an image you must also provide a tag")
-                    extra_annotations = {
-                        "hub.jupyter.org/username": user.name,
-                        "prometheus.io/scrape": "true",
-                        "prometheus.io/port": "8787",
-                    }
-                    extra_labels = {
-                        "hub.jupyter.org/username": user.name,
-                    }
-                    return {
-                        "worker_cores_limit": options.worker_cores,
-                        "worker_cores": min(options.worker_cores / 2, 1),
-                        "worker_memory": "%fG" % options.worker_memory,
-                        "image": options.image,
-                        "scheduler_extra_pod_annotations": extra_annotations,
-                        "worker_extra_pod_annotations": extra_annotations,
-                        "scheduler_extra_pod_labels": extra_labels,
-                        "worker_extra_pod_labels": extra_labels,
-                    }
-                return Options(
-                    Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
-                    Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
-                    String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
-                    handler=option_handler,
-                )
-              c.Backend.cluster_options = cluster_options
             idle: |
               # timeout after 30 minutes of inactivity
               c.KubeClusterConfig.idle_timeout = 1800

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -151,7 +151,7 @@ dask-gateway:
     # TODO: figure out a replacement for userLimits.
     extraConfig:
       optionHandler: |
-        from dask_gateway_server.options import Options, Integer, Float, String
+        from dask_gateway_server.options import Options, Integer, Float, String, Mapping
 
         def cluster_options(user):
             def option_handler(options):
@@ -176,11 +176,13 @@ dask-gateway:
                     "worker_extra_pod_annotations": extra_annotations,
                     "scheduler_extra_pod_labels": extra_labels,
                     "worker_extra_pod_labels": extra_labels,
+                    "environment": options.environment,
                 }
             return Options(
                 Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
                 Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
                 String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+                Mapping("environment", {}, label="Environment Variables"),
                 handler=option_handler,
             )
         c.Backend.cluster_options = cluster_options

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -181,7 +181,8 @@ dask-gateway:
             return Options(
                 Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
                 Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
-                String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+                # The default image is set via DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE env variable
+                String("image", label="Image"),
                 Mapping("environment", {}, label="Environment Variables"),
                 handler=option_handler,
             )


### PR DESCRIPTION
Remove duplicated dask-gateway config from carbonplan & openscapes
hub as well.

Ref https://github.com/2i2c-org/pilot-hubs/issues/291#issuecomment-842655717