### PR TITLE
Reduce memory request for carbonplan r5.8x instance

### DIFF
--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -89,7 +89,7 @@ hubs:
                 description: "~32 CPU, ~256G RAM"
                 kubespawner_override:
                   mem_limit: null
-                  mem_guarantee: 250G
+                  mem_guarantee: 240G
                   node_selector:
                     node.kubernetes.io/instance-type: r5.8xlarge
           scheduling:


### PR DESCRIPTION
They apparently have less than 250G total allocatable space,
despite having 256G total RAM

Ref https://github.com/2i2c-org/pilot-hubs/issues/291