### PR TITLE
Switch to Auth0OAuthenticator

### DIFF
--- a/deployer/auth.py
+++ b/deployer/auth.py
@@ -1,6 +1,8 @@
 from auth0.v3.authentication import GetToken
 from auth0.v3.management import Auth0
 
+import re
+
 # What key in the authenticated user's profile to use as hub username
 # This shouldn't be changeable by the user!
 USERNAME_KEYS = {
@@ -159,15 +161,13 @@ class KeyProvider:
         """
 
         auth = {
-            'authorize_url': f'https://{self.domain}/authorize',
-            'token_url': f'https://{self.domain}/oauth/token',
+            'auth0_subdomain': re.sub('\.auth0.com$', '', self.domain),
             'userdata_url': f'https://{self.domain}/userinfo',
-            'userdata_method': 'GET',
             'username_key': USERNAME_KEYS[connection_name],
             'client_id': client['client_id'],
             'client_secret': client['client_secret'],
             'scope': ['openid', 'name', 'profile', 'email'],
-            'logout_redirect_url': f'https://{self.domain}/v2/logout?client_id={client["client_id"]}'
+            'logout_redirect_url': f'https://{self.domain}/v2/logout?client_id={client["client_id"]}?returnTo={client[logout_urls][0]}'
         }
 
         return auth

--- a/deployer/auth.py
+++ b/deployer/auth.py
@@ -1,6 +1,7 @@
 from auth0.v3.authentication import GetToken
 from auth0.v3.management import Auth0
 
+from tornado.httputil import url_concat
 import re
 
 # What key in the authenticated user's profile to use as hub username
@@ -160,6 +161,11 @@ class KeyProvider:
         Return z2jh config for auth0 authentication for this JupyterHub
         """
 
+        logout_redirect_params = {
+            'client_id': client["client_id"],
+            'returnTo': client["allowed_logout_urls"][0]
+        }
+
         auth = {
             'auth0_subdomain': re.sub('\.auth0.com$', '', self.domain),
             'userdata_url': f'https://{self.domain}/userinfo',
@@ -167,7 +173,7 @@ class KeyProvider:
             'client_id': client['client_id'],
             'client_secret': client['client_secret'],
             'scope': ['openid', 'name', 'profile', 'email'],
-            'logout_redirect_url': f'https://{self.domain}/v2/logout?client_id={client["client_id"]}?returnTo={client[logout_urls][0]}'
+            'logout_redirect_url': url_concat(f'https://{self.domain}/v2/logout', logout_redirect_params)
         }
 
         return auth

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -255,7 +255,7 @@ class Hub:
             # FIXME: We're hardcoding GenericOAuthenticator here
             # We should *not*. We need dictionary merging in code, so
             # these can all exist fine.
-            generated_config['jupyterhub']['hub']['config']['GenericOAuthenticator'] = auth_provider.get_client_creds(client, self.spec['auth0']['connection'])
+            generated_config['jupyterhub']['hub']['config']['Auth0OAuthenticator'] = auth_provider.get_client_creds(client, self.spec['auth0']['connection'])
 
         return self.apply_hub_template_fixes(generated_config, secret_key)
 

--- a/hub-templates/basehub/Chart.yaml
+++ b/hub-templates/basehub/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: Deployment Chart for JupyterHub
 name: basehub
 # Let's keep this constant so other charts in this repo can depend on this easily
-version: 0.0.1-n569.hb296398
+version: 0.0.1-n769.hfd04ce8
 dependencies:
   - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -179,7 +179,7 @@ jupyterhub:
           - --Configurator.config_file=/usr/local/etc/jupyterhub-configurator/jupyterhub_configurator_config.py
     image:
       name: quay.io/2i2c/pilot-hub
-      tag: '0.0.1-n569.hb296398'
+      tag: '0.0.1-n769.hfd04ce8'
     config:
       JupyterHub:
         authenticator_class: oauthenticator.auth0.Auth0OAuthenticator

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -182,7 +182,7 @@ jupyterhub:
       tag: '0.0.1-n569.hb296398'
     config:
       JupyterHub:
-        authenticator_class: oauthenticator.generic.GenericOAuthenticator
+        authenticator_class: oauthenticator.auth0.Auth0OAuthenticator
     nodeSelector:
       hub.jupyter.org/node-purpose: core
     networkPolicy:
@@ -270,40 +270,9 @@ jupyterhub:
         c.JupyterHub.spawner_class = CustomSpawner
 
       06-custom-authenticator: |
-        from oauthenticator.generic import GenericOAuthenticator
-        from jupyterhub.handlers import LogoutHandler
-        from tornado.httputil import url_concat
-        from traitlets import Unicode
-        from z2jh import get_config
+        from oauthenticator.auth0 import Auth0OAuthenticator
 
-        class CustomLogoutHandler(LogoutHandler):
-          """
-          Handle custom logout URLs. If a custom logout url
-          is specified, the 'logout' button will log the user out of that identity
-          provider in addition to clearing the session with Jupyterhub, otherwise
-          only the Jupyterhub session is cleared.
-          """
-
-          async def render_logout_page(self):
-            if self.authenticator.logout_redirect_url:
-              # Return to the hub main page after logout
-              params = {
-                'returnTo': f'https://{self.request.host}'
-              }
-              self.redirect(
-                url_concat(self.authenticator.logout_redirect_url, params),
-                permanent=False
-              )
-              return
-
-            super().render_logout_page()
-
-        class CustomOAuthenticator(GenericOAuthenticator):
-          logout_redirect_url = Unicode(help="""URL for logging out.""", default_value='').tag(config=True)
-
-          def get_handlers(self, app):
-            return super().get_handlers(app) + [(r'/logout', CustomLogoutHandler)]
-
+        class CustomOAuthenticator(Auth0OAuthenticator):
           async def authenticate(self, *args, **kwargs):
             resp = await super().authenticate(*args, **kwargs)
             if self.username_key == 'sub':

--- a/hub-templates/images/hub/Dockerfile
+++ b/hub-templates/images/hub/Dockerfile
@@ -6,6 +6,10 @@ ENV CONFIGURATOR_VERSION ed7e3a0df1e3d625d10903ef7d7fd9c2fbb548db
 
 RUN pip install --no-cache git+https://github.com/yuvipanda/jupyterhub-configurator@${CONFIGURATOR_VERSION}
 
+ENV OAUTHENTICATOR_VERSION 878cec5f3008d8502256253e6d155e8a8ed0cd98
+
+RUN pip install --no-cache git+https://github.com/jupyterhub/oauthenticator@${OAUTHENTICATOR_VERSION}
+
 USER root
 RUN mkdir -p /usr/local/etc/jupyterhub-configurator
 


### PR DESCRIPTION
This should work once we'll be using an `oauthenticator` version that has these changes: https://github.com/jupyterhub/oauthenticator/pull/439 and https://github.com/jupyterhub/oauthenticator/pull/437

Steps to have this PR ready for review:
- [x] Have the two `oauthenticator` PRs mentioned above, merged
- [x] Use OAuthenticator main branch in `pilot-hubs` hub image (https://github.com/2i2c-org/pilot-hubs/tree/master/hub-templates/images/hub)