### PR TITLE
Fix schema error by moving admin_users under Authenticator

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -297,7 +297,7 @@ hubs:
                 - ericvd@gmail.com
                 - sean.smorris@berkeley.edu
                 - william.kerney@cloviscollege.edu
-          admin_users: *clovis_users
+              admin_users: *clovis_users
   - name: sbcc
     domain: sbcc.cloudbank.2i2c.cloud
     template: basehub


### PR DESCRIPTION
There is a [schema validation error](https://github.com/2i2c-org/pilot-hubs/runs/2720750412) when deploying the cloudbank hubs. This should fix it.

Unfortunately, the deployment of the hubs from the 2i2c cluster is failing too and [the error is pretty vague](https://github.com/2i2c-org/pilot-hubs/runs/2720750369) :(