### PR TITLE
Add docs service api token

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -294,9 +294,11 @@ class Hub:
 
         }
 
+        docs_token = hmac.new(secret_key, f'docs-{self.spec["name"]}'.encode(), hashlib.sha256).hexdigest()
         if 'docs_service' in self.spec['config'].keys() and self.spec['config']['docs_service']['enabled']:
             generated_config['jupyterhub']['hub']['services']['docs'] = {
-                'url': f'http://docs-service.{self.spec["name"]}'
+                'url': f'http://docs-service.{self.spec["name"]}',
+                'apiToken': docs_token
             }
 
 


### PR DESCRIPTION
I couldn't identify exactly what changed with the new z2jh to v1.0 beta, but it seems that we need to specify an api token for the docs service now. When we first added the docs service, we concluded that because the service didn't make any API calls, then we didn't need a token ([ref](https://github.com/2i2c-org/pilot-hubs/pull/177#discussion_r564686610))