### PR TITLE
Emit array from openscapes.jsonnet

### DIFF
--- a/kops/openscapes.jsonnet
+++ b/kops/openscapes.jsonnet
@@ -90,7 +90,7 @@ local data = {
     ]
 };
 
-{ 'kops.yaml': [
+[
     data.cluster,
     data.master
-] + data.notebookNodes + data.daskNodes}
+] + data.notebookNodes + data.daskNodes


### PR DESCRIPTION
- `jsonnet -y` expects an array to emit as multiple documents.
  It unfortunately ends with a `...` at the end (since it is a YAML
  stream) which has to be manually removed before we can pass it to
  kops.
- -m <dirname> can emit different files in a directory, and we can
  emit one file each for cluster, master, etc. The code in this
  PR didn't actually do that either, it was just invalid YAML.

Right now, I prefer the 1 file format, so sticking to the format
that works with `-y`.