### PR TITLE
Fix logout handling - transition to a new naming scheme on registered OAuth2 application in Auth0

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -192,6 +192,8 @@ hubs:
     template: basehub
     auth0:
       connection: password
+      password:
+        database_name: database-demo
     config:
       jupyterhub:
         custom:

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -1,4 +1,4 @@
-$schema: 'http://json-schema.org/draft-04/schema#'
+$schema: 'http://json-schema.org/draft-07/schema#'
 type: object
 additionalProperties: false
 properties:

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -126,6 +126,28 @@ properties:
                   Authentication method users of the hub can use to log in to the hub.
                   We support a subset of the [connectors](https://auth0.com/docs/identityproviders)
                   that auth0 supports
+              application_name:
+                type: string
+                description: |
+                  We make use of an OAuth2 applications in Auth0 and this is the
+                  name of that application. Defaults to
+                  "<clustername>-<hubname>".
+
+                  See https://manage.auth0.com/dashboard/us/2i2c/applications.
+              password:
+                type: object
+                description: |
+                  Configuration specific to a connection of type password.
+                properties:
+                  database_name:
+                    type: string
+                    description: |
+                      Username and password authentication requires a Auth0
+                      database to store the username and passwords in. This is
+                      the name of that Auth0 database. Defaults to
+                      "<clustername>-<hubname>".
+
+                      See https://manage.auth0.com/dashboard/us/2i2c/connections/database.
             required:
               - connection
           config:

--- a/deployer/auth.py
+++ b/deployer/auth.py
@@ -101,8 +101,7 @@ class KeyProvider:
                 }
             )
 
-
-    def ensure_client(self, name, domains, connection_name):
+    def ensure_client(self, name, domains, connection_name, connection_config):
         current_clients = self.get_clients()
         if name not in current_clients:
             # Create the client, all good
@@ -119,7 +118,7 @@ class KeyProvider:
             # should have its own username / password database.
             # So we create a new 'database connection' per hub,
             # instead of sharing one across hubs.
-            db_connection_name = f'database-{name}'
+            db_connection_name = connection_config.get("database_name", name)
 
             if db_connection_name not in current_connections:
                 # connection doesn't exist yet, create it
@@ -134,7 +133,7 @@ class KeyProvider:
             selected_connection_name = connection_name
 
         for connection in current_connections.values():
-                # The chosen connection!
+            # The chosen connection!
             enabled_clients = connection['enabled_clients'].copy()
             needs_update = False
             client_id = client['client_id']

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -246,9 +246,8 @@ class Hub:
         #
         # Allow explicilty ignoring auth0 setup
         if self.spec['auth0'].get('enabled', True):
-
             client = auth_provider.ensure_client(
-                self.spec['name'],
+                self.cluster.spec['name'],
                 self.spec['domain'],
                 self.spec['auth0']['connection']
             )

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -247,7 +247,7 @@ class Hub:
         # Allow explicilty ignoring auth0 setup
         if self.spec['auth0'].get('enabled', True):
             client = auth_provider.ensure_client(
-                self.cluster.spec['name'],
+                f"{self.cluster.spec['name']}-{self.spec['name']}",
                 self.spec['domain'],
                 self.spec['auth0']['connection']
             )

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -247,9 +247,10 @@ class Hub:
         # Allow explicilty ignoring auth0 setup
         if self.spec['auth0'].get('enabled', True):
             client = auth_provider.ensure_client(
-                f"{self.cluster.spec['name']}-{self.spec['name']}",
-                self.spec['domain'],
-                self.spec['auth0']['connection']
+                name=               self.spec['auth0'].get('application_name', f"{self.cluster.spec['name']}-{self.spec['name']}"),
+                domains=            self.spec['domain'],
+                connection_name=    self.spec['auth0']['connection'],
+                connection_config=  self.spec['auth0'].get(self.spec['auth0']['connection'], {}),
             )
             # FIXME: We're hardcoding GenericOAuthenticator here
             # We should *not*. We need dictionary merging in code, so

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -247,10 +247,10 @@ class Hub:
         # Allow explicilty ignoring auth0 setup
         if self.spec['auth0'].get('enabled', True):
             client = auth_provider.ensure_client(
-                name=               self.spec['auth0'].get('application_name', f"{self.cluster.spec['name']}-{self.spec['name']}"),
-                domains=            self.spec['domain'],
-                connection_name=    self.spec['auth0']['connection'],
-                connection_config=  self.spec['auth0'].get(self.spec['auth0']['connection'], {}),
+                name=self.spec['auth0'].get('application_name', f"{self.cluster.spec['name']}-{self.spec['name']}"),
+                domains=self.spec['domain'],
+                connection_name=self.spec['auth0']['connection'],
+                connection_config=self.spec['auth0'].get(self.spec['auth0']['connection'], {}),
             )
             # FIXME: We're hardcoding GenericOAuthenticator here
             # We should *not*. We need dictionary merging in code, so


### PR DESCRIPTION
This closes #447.

Previously we were using a `<clustername>` format for the name of the Auth0 registered OAuth2 application, but the logout action assumed a `<hubname>` format. It seems we have consensus on opting for a `<clustername>-<hubname>` format at this point so this PR is about transitioning to that.

## Action points pre-merge

- [x] Decide on the new format `clutsername-hubname` (DECIDED ON THIS)
- [x] Alternatively, decide it is preferable with more explicit configuration.
    I imagine an option to assuming a `clusternane-hubname` pattern, that a more explicit config option mentioning the Auth0 registered OAuth2 application name could be less magic and make it more clear what's going on.
    ```yaml
    hubs:
      - name: staging
        domain: staging.carbonplan.2i2c.cloud
        template: daskhub
        auth0:
          connection: github
          application_name: carbonplan-staging
    ```
- [x] Ensure we reference the new OAuth2 application also on /hub/logout
- [x] Ensure we reference the new OAuth2 application format on /hub/login
- [x] Ensure we don't run into issues based on the logic discussed here: https://github.com/2i2c-org/pilot-hubs/pull/448#discussion_r644910435
- [x] In Auth0: register new OAuth2 applications following the new format for all hubs we have
  Update: this is not needed, they are automatically created.

## Action points post-merge

- [ ] Verify successful deployment, what needs testing is the login and logout action
- [ ] In Auth0: delete the old OAuth2 applications following the old format for all hubs we have