### PR TITLE
Fix typo on openscapes jsonnet

### DIFF
--- a/kops/openscapes.jsonnet
+++ b/kops/openscapes.jsonnet
@@ -27,7 +27,7 @@ local data = {
             name: "master"
         },
         spec+: {
-            machineType: "m5.medium",
+            machineType: "t3.medium",
             subnets: [zone],
             nodeLabels+: {
                 "hub.jupyter.org/node-purpose": "core",


### PR DESCRIPTION
This didn't have any effect on the deployed cluster. I
verified this with:

1. jsonnet openscapes.jsonnet -y > openscapes.kops.yaml
2. Remove `...` at end of the file
3. kops replace -f openscapes.kops.yaml
4. kops rolling-update cluster. This has no effects, so it was already
   the correct setup.