### PR TITLE
Provision per-cluster support components

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -27,6 +27,10 @@ runs:
         python3 -m pip install -r requirements.txt
         python3 -m pip install -r dev-requirements.txt
       shell: bash
+    - name: Deploy support components
+      run: |
+        python3 deployer deploy-support ${{ inputs.cluster }}
+      shell: bash
     - name: Deploy and test hubs
       run: |
         python3 deployer deploy ${{ inputs.cluster }}

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -5,3 +5,5 @@ creation_rules:
     gcp_kms: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
   - path_regex: config/secrets.yaml$
     gcp_kms: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+  - path_regex: support/secrets.yaml$
+    gcp_kms: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs

--- a/support/secrets.yaml
+++ b/support/secrets.yaml
@@ -1,0 +1,16 @@
+grafana:
+    adminPassword: ENC[AES256_GCM,data:vuzbI2lRpVSihmzQmQ38BD7N2rKSQ5YR4UcgsyKWsQGQBA5yfZvVj8osDOjEYVoZLDijRI6IJHfqZ4SaFMMg8w==,iv:U9m6wTNVVJDiHufBeaD0nBPMTjleDu2pKcR8G83/H1s=,tag:BDflHP0IzmNSRt5j2k9nrg==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2021-06-16T12:29:14Z"
+          enc: CiQA4OM7eOWv40yySpNyEbCz1opatQP5+t5LrofdgGRay6VmYBgSSQB6TpsYWgnbo18yEE/gn9tYk5gkuqm/Jg3DPAXDWmyDDb819DrTw17vDUc/yBxmRrxaCVfsefMLV5PSejDvszU8WGwJgYUq01Y=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-06-16T12:32:16Z"
+    mac: ENC[AES256_GCM,data:XTX8q2v21rNSzFqIUegqpk0Ne2erEKbxm42LnEu+lpGIdQ4dw1ebsri8WslalOAxklZYPXut+zOV6E0gyoiLmJO9dblj/HgdInDqf42AjS91RUSGXQH2otz6ajmU0GrUHehSAVRC7tRKqgp819NudNmcgfdF32N9g1W1Mab0z8s=,iv:FPv2Jjxgsa0mk+n9eOoaAvtCTY2RDOyjB0BY+bz2hv4=,tag:qgoq9CduOQbQcX5Vr8sXoA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1


### PR DESCRIPTION
- Set up cert-manager explicitly, since it can not be set up as
  a dependent chart of our 'support' chart.
- 'support' chart deploys prometheus, grafana and nginx-ingress
  in a standard configuration.
- Allow per-cluster overrides with config under support/clusters.
- Automates auth to cluster for automated deployment
- Puts config overrides in same place as cluster config, to
  avoid duplication
- Sets up HTTPS for the 2i2c pilot hubs grafana

Ref https://github.com/2i2c-org/pilot-hubs/issues/388

TODO
- [x] Setup auth for grafana
- [x] Deploy with CI / CD