### PR TITLE
Remove support for more than 1 domain per hub

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -335,9 +335,7 @@ hubs:
                 - nfguebels@pipeline.sbcc.edu
               admin_users: *sbcc_users
   - name: mills
-    domain:
-      - mills.cloudbank.2i2c.cloud
-      - datahub.mills.edu
+    domain: datahub.mills.edu
     template: basehub
     auth0:
       connection: google-oauth2

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -16,14 +16,14 @@ properties:
       Cloud provider this cluster is running on. Used to perform
       authentication against the cluster. Currently supports gcp
       and raw kubeconfig files.
-    enum: 
+    enum:
       - gcp
       - kubeconfig
   kubeconfig:
     type: object
     description: |
       Configuration to connect to a cluster purely via a kubeconfig
-      file. 
+      file.
     additionalProperties: false
     properties:
       file:
@@ -83,28 +83,22 @@ properties:
               Name of the hub. This will be used to determine
               the namespace the hub is deployed to
           domain:
-            anyOf:
-              - type: string 
-                description: |
-                  Domain the hub should be running on. This domain should resolve
-                  to the IP of the ingress controller on the cluster - most likely
-                  via a wildcard DNS entry. 
+            type: string
+            description: |
+              Domain the hub should be running on. This domain should resolve
+              to the IP of the ingress controller on the cluster - most likely
+              via a wildcard DNS entry.
 
-                  For example, there's a entry for '*.pilot.2i2c.cloud' pointing to
-                  the ingress controller of the cluster running hubs in `2i2c.cluster.yaml`.
-                  Similar for '*.cloudbank.2i2c.cloud', etc.
-              - type: array
-                description: |
-                  Multiple domain names that can resolve to this hub. Primarily
-                  used as a way to redirect old hub URLs to new - should be replaced
-                  with something nicer.
+              For example, there's a entry for '*.pilot.2i2c.cloud' pointing to
+              the ingress controller of the cluster running hubs in `2i2c.cluster.yaml`.
+              Similar for '*.cloudbank.2i2c.cloud', etc.
           template:
             type: string
             description: |
               Template to deploy the hub with. This refers to a directory under
               `hub-templates` containing a helm chart with base values and dependencies
               that determine the kind of hub deployed.
-            enum: 
+            enum:
               - basehub
               - daskhub
           auth0:

--- a/deployer/auth.py
+++ b/deployer/auth.py
@@ -82,7 +82,7 @@ class KeyProvider:
                 client['client_id'],
                 {
                     # Overwrite any other logout URL - users should only land on
-                    # the hug home page after logging out.
+                    # the hub home page after logging out.
                     'allowed_logout_urls': [logout_url]
                 }
             )


### PR DESCRIPTION
Multiple domains were supported primarily to make sure hubs
are reachable by both datahub.mills.edu and mills.cloudbank.2i2c.cloud.
In practice, nobody uses the second URL, and this just confuses
the deployer code. datahub.mills.edu is a CNAME to
mills.cloudbank.2i2c.cloud - but that doesn't require the latter
to actually serve any content (over HTTP). CNAME is a DNS feature,
so we don't actually have to do anything wrt HTTP serving.

Includes slight refactoring to make auth.KeyProvider a little more
agnostic to just using with JupyterHubs - could perhaps be used
with https://github.com/2i2c-org/pilot-hubs/pull/456 in providing
OAuth credentials for grafana too