### PR TITLE
Fix schema definition for cluster config

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -452,8 +452,7 @@ hubs:
                 - sanjay.dorairaj@sjcc.edu
               admin_users: *sjcc_users
   - name: avc
-    domain:
-      - avc.cloudbank.2i2c.cloud
+    domain: avc.cloudbank.2i2c.cloud
     template: basehub
     auth0:
       connection: google-oauth2

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -10,6 +10,17 @@ properties:
       {name}.cluster.yaml
   image_repo:
     type: string
+  support:
+    type: object
+    additionalProperties: false
+    description: |
+      Configuration for support components (ingress, monitoring, etc)
+      to be enabled for this cluster.
+    properties:
+      config:
+        type: object
+        description: |
+          Additional YAML values to be deployed with the support chart
   provider:
     type: string
     description: |


### PR DESCRIPTION
- Follow-up to https://github.com/2i2c-org/pilot-hubs/pull/458 -
  domain can not be list anymore with https://github.com/2i2c-org/pilot-hubs/pull/460
- Support components config for each cluster is also now present
  in the cluster.yaml config files, with
  https://github.com/2i2c-org/pilot-hubs/pull/456. Even though
  that has not been merged yet, it is already deployed. This PR
  updates the schema to allow the support config.