### PR TITLE
Cleanup pytest output in GitHub actions

### DIFF
--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -2,7 +2,7 @@ auth0:
     domain: ENC[AES256_GCM,data:aEi/GvnxpyGsvinhZ5sXXto=,iv:SR6sgQronhovtuUpQnSuIO2KFo9eTSP9tgFqg+QBJ8I=,tag:6yzNIPmFEWilI1qajTH1WQ==,type:str]
     client_id: ENC[AES256_GCM,data:aHw7KJCg4Hn2RiLIiONQXnc48/JFsCCnW0WFVLtCFgM=,iv:FFxe1kNtBh5ljroqCTW3wicQzyDszSCSyYx4Boe2Dns=,tag:a/m2QDTrcKpurKq0IZPjOw==,type:str]
     client_secret: ENC[AES256_GCM,data:B+fw9jZUc2b0Mb9CD/Pas+aZLPd3Rp1GI6Wrq0wXYcE5HvMEOXhXOqzl9nEKhbR/cVAh5YZt+xlI8G2zOraWbQ==,iv:nDIxzcuQ5Noxp7HyYsL02hBRDLi9An5MN8IEdLnLffA=,tag:T4GgBUkzfSV5UC8RX8yT2g==,type:str]
-secret_key: ENC[AES256_GCM,data:qW7+NtYj3MB6eMjTnMJQ36stcKONkHzKYkn9sflbJuwX3fwYGIvDQg2Rf2LDWAj8z40NC/zdabMaFGiEredo5Q==,iv:KOpUcN9jSpmwIYuUqOidhoapdo5zagw4tXhQvmVfPDU=,tag:vwUI0Z3OIivLRZ5W8DjZRA==,type:str]
+secret_key: ENC[AES256_GCM,data:ZT5kb64zUJIEKhUQSKgCRF8HcEnvK59KCtVs6TEO+O3S5qWBJIJY9kivlYU8a93XRN9cxIi9YlG4EfLoFR5JUw==,iv:V5OKGcKfG6s4EKdonrosvFJPltujSp5z4SZ8th9SkYs=,tag:jqQcK4+HO+i8SLerABYxeQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -12,8 +12,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-04-20T12:00:51Z"
-    mac: ENC[AES256_GCM,data:2DN2eV24vFWm3Zk5YAnYDZ7oPoGwJKKKByIkQQO5Z879nBbFrJKAfsF+WnVA3BfuuFEBW/iSYP+933m7O4yRfLH4P07/HUYasq7g9pXHxgZdQZzdVb5QiGQmYGYnvvDjcJFGLJxp/c/v59GkkIRvjtU9QZbb7fd4KnRJV4keRXw=,iv:wa9s1Sur7/KCJlsMWnQtDMIL7WPX0Zup96ncj4/vdMM=,tag:KwYctS7BtHpJIbg6x8WnDQ==,type:str]
+    lastmodified: "2021-06-11T06:36:56Z"
+    mac: ENC[AES256_GCM,data:oW0k09Gd65XK0OxRcX9jPaDMatFPrE42A6rdIHvKNQBmM2MY+VECKLbDzci1Ob9VZsp91ss0psn0im28z9G/Fjf6adRwXjtnI7k5KkEwkwivxpnk9RX+ZyPkFn4ccnhbHEciRU4NVS1upFJLCGDs9EBZ6FTXzMEx5aL2jUlLXYA=,iv:oaIR4rwUgcLpEFo19kziEuNJwf407NHPQVsM2pPRvxY=,tag:zozw57Qc1CYVj6TLkiyPlQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1


### PR DESCRIPTION
- On failure, we've been printing per-hub API token in GitHub
  action. This hides it.
- Rotating the secret base key helps change all previously
  exposed api keys