### PR TITLE
Push preliminary AWS deployment documentation

### DIFF
--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -140,7 +140,7 @@ kubectl -n kube-system patch deployment kube-dns-autoscaler --type json --patch 
 
 ### Create an EFS for your cluster
 
-1. Install boto3 with pip or conda
+1. Install `boto3` with pip or conda
 
 2. Create an [EFS](https://aws.amazon.com/efs/) file system for this hub with
 

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -127,7 +127,7 @@ But validation will not pass until this next section is done.
 More details [in this issue](https://github.com/kubernetes/kops/issues/11199)
 ```
 
-1. After the failed validation finished (you can run these command in another terminal 
+1. After the failed validation finished (you can run these commands in another terminal 
 if you are impatient ;-) patch CoreDNS with
 
 ```bash

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -44,7 +44,7 @@ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
 [state](https://kops.sigs.k8s.io/state/).
 
 ``` bash
-export KOPS_STATE_STORE=s3://2i2c-<hub-name>-kops-state
+export KOPS_STATE_STORE=s3://2i2c-<cluster-name>-kops-state
 aws s3 mb $KOPS_STATE_STORE --region <region>
 ```
 

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -169,9 +169,7 @@ sops -i -e secrets/<cluster_name>.yaml
 
 4. Generate a new config file for your cluster
 
-You can use 
-[one](https://github.com/2i2c-org/pilot-hubs/blob/master/config/hubs/farallon.cluster.yaml)
-of the existing cluster config files as a "template" for your cluster.
+You can use of the existing cluster config files as a "template" for your cluster (for example, [here is the Farallon Institute config file](https://github.com/2i2c-org/pilot-hubs/blob/master/config/hubs/farallon.cluster.yaml)).
 You may need to tweak names, `serverIP` and singleuser's images references. Make sure 
 you set up the `profileList` section to be compatible with your kops cluster (ie. match 
 the `node_selector` with the proper `instance-type`).

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -95,11 +95,6 @@ mv ssh-key <cluster_name>.key
 mv ssh-key.pub <cluster_name>.key.pub
 ```
 
-```{note}
-You will need to relocate and encrypt the private key before pushing your changes to the
-repository.
-```
-
 3. Build the cluster with the following command (notice that you are passing the ssh public key you just 
 created in the previous step)
 
@@ -120,6 +115,23 @@ kops validate cluster --wait 10m
 ```
 
 But validation will not pass until this next section is done.
+
+4. Relocate and encrypt the generated keys
+
+After creating the cluster, you will need to relocate the public and private keys with
+
+```bash
+mv <cluster_name>.key ssh-keys/<cluster_name>.key
+mv <cluster_name>.key.pub ssh-keys/<cluster_name>.key.pub
+```
+
+and encrypt the private key with
+
+```bash
+sops -i -e ssh-keys/<cluster_name>.key
+```
+
+before pushing your changes to the repository.
 
 ### Apply workaround to run CoreDNS on the master node
 

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -1,0 +1,211 @@
+# Add a new hub in a AWS kops-based cluster
+
+The idea behind this guide is showcase the process of setting up a 
+[kops](https://kops.sigs.k8s.io/getting_started/aws/)-based AWS
+cluster and manually deploy a new hub on top of it using our deployer tool.
+This is a preliminary but fully functional and manual process. Once
+[#381](https://github.com/2i2c-org/pilot-hubs/issues/381) is resolved, we should be able
+to automate the hub deployment process as we currently do with the GKE-based hubs.
+
+```{note}
+We will continue working toward a definitive one once we figured out some of the
+discussions outlined in [#431](https://github.com/2i2c-org/pilot-hubs/issues/431).
+```
+
+## Pre-requisites
+
+1. Follow the instructions outlined in
+[Set up and use the the deployment scripts locally](./manual-deploy.md) to set up the
+local environment and prepare `sops` to encrypt and decrypt files.
+
+2. Install the awscli tool (you can use pip or conda to install it in the environment)
+and configure it to use the provided AWS user credentials. Follow this
+[guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config)
+for a quick configuration process.
+
+```{note}
+The customer with AWS admin privileges should have created a user for you with full
+privileges. We will probably explore fine-graining the permissions actually needed
+in the short-term.
+```
+
+3. Export some helpful AWS environment variables (because "aws configure" doesn't export
+these environments vars for kops to use, so we do it manually).
+
+```bash
+export AWS_PROFILE=<cluster_name>
+export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
+```
+
+## Create an AWS kops-based cluster
+
+1. From the root directory on this repo, `cd` into the `kops` directory
+2. Set up a *state* bucket for kops. This bucket will store the cluster
+[state](https://kops.sigs.k8s.io/state/).
+
+``` bash
+export KOPS_STATE_STORE=s3://<2i2c>-<hub-name>-kops-state
+aws s3 mb $KOPS_STATE_STORE --region <region>
+```
+
+```{note}
+Kops [recommends](https://kops.sigs.k8s.io/getting_started/aws/#cluster-state-storage)
+versioning the S3 bucket in case you ever need to revert or recover a previous state
+store.
+```
+
+### Create and render a kops config file
+
+You can use 
+[one](https://github.com/2i2c-org/pilot-hubs/blob/master/kops/farallon.jsonnet) of the
+existing [jsonnet](https://jsonnet.org/) specifications as a "template" for your cluster.
+You may need to tweak zones, names and instances, the rest is boilerplate to create a
+kops-based cluster accordingly to some specification already outlined in 
+[#28](https://github.com/2i2c-org/pangeo-hubs/issues/28). Once you have your jsonnet
+specification ready, you need to render it to create the config file kops understand.
+
+1. Render the `kops` config file with
+
+```bash
+jsonnet <cluster_name>.jsonnet -y > <cluster_name>.kops.yaml
+```
+
+2. Regrettably, the rendering creates yaml file with with 3 dots at the end, you can 
+delete it with
+
+```bash
+sed -i '' -e '$ d' <cluster_name>.kops.yaml
+```
+
+```{note}
+In Linux you will need to use instead: `sed -i '$ d' <cluster_name>.kops.yaml`
+```
+
+### Create the cluster
+
+1. Create the cluster configuration and push it to s3 with
+
+```bash
+kops create -f <cluster_name>.kops.yaml
+```
+
+2. You will need to a ssh key pair before actually creating the cluster
+
+```bash
+ssh-keygen -f ssh-key
+mv ssh-key <cluster_name>.key
+mv ssh-key.pub <cluster_name>.key.pub
+```
+
+```{note}
+You will need to relocate and encrypt the private key before pushing your changes to the
+repository.
+```
+
+3. Build the cluster with (notice that you are passing the ssh public key you just 
+created in the previous step)
+
+```bash
+kops update cluster <cluster_name>hub.k8s.local --yes --ssh-public-key <cluster_name>.key.pub --admin
+```
+
+```{note}
+The `--admin` at the end will modify your `~/.kube/config` file to point to the new 
+cluster.
+```
+
+If everything went as expected, the cluster will be created after some minutes, and you 
+should be able to validate it with
+
+```bash
+kops validate cluster --wait 10m
+```
+
+But validation will not pass until this next section is done.
+
+### Apply workaround to run CoreDNS on the master node
+
+More details on this [issue](https://github.com/kubernetes/kops/issues/11199)
+
+1. After the failed validation finished (you can run these command in another terminal 
+if you are impatient ;-) patch CoreDNS with
+
+```bash
+kubectl -n kube-system patch deployment kube-dns --type json --patch '[{"op": "add", "path": "/spec/template/spec/tolerations", "value": [{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]}]'
+deployment.apps/kube-dns patched
+
+kubectl -n kube-system patch deployment kube-dns-autoscaler --type json --patch '[{"op": "add", "path": "/spec/template/spec/tolerations", "value": [{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]}]'
+```
+
+### Create an EFS for your cluster
+
+1. Install boto3 with pip or conda
+
+2. Create an [EFS](https://aws.amazon.com/efs/) file system for this hub with
+
+```bash
+python3 setup-efs.py <cluster_name>hub.k8s.local us-east-2
+```
+
+This will output an fs-<xxxxxxxx> id. You should use that value 
+(it should be something like `fs-<id>.efs.<region>.amazonaws.com`) in
+the `basehub.nfsPVC.nfs.serverIP` at you hub config file. 
+
+## Deploy the new hub
+
+1. First, `cd` back to the root of the repository
+
+2. Generate a kubeconfig that will be used by the deployer with
+
+```bash
+KUBECONFIG=secrets/<cluster_name>.yaml kops export kubecfg --admin=730h <cluster_name>hub.k8s.local
+```
+
+3. Encrypt (in-place) the generated kubeconfig with sops
+
+```bash
+sops -i -e secrets/<cluster_name>.yaml
+```
+
+4. Generate a new config file for your cluster
+
+You can use 
+[one](https://github.com/2i2c-org/pilot-hubs/blob/master/config/hubs/farallon.cluster.yaml)
+of the existing cluster config files as a "template" for your cluster.
+You may need to tweak names, `serverIP` and singleuser's images references. Make sure 
+you set up the `profileList` section to be compatible with your kops cluster (ie. match 
+the `node_selector` with the proper `instance-type`).
+
+5. Set `proxy.https.enabled` to `false`. This creates the hubs without trying to give 
+them HTTPS, so we can appropriately create DNS entries for them.
+
+6. Deploy the hub (or hubs in case you are deploying more than one) without running the
+test with
+
+```bash
+python3 deployer deploy <cluster_name> --skip-hub-health-test
+```
+
+7. Get the AWS external IP for your hub with (supposing your hub is `staging`):
+
+```bash
+kubectl -n staging get svc proxy-public
+```
+
+Create a CNAME record for `staging.foo.2i2c.cloud` and point it to the AWS external IP.
+
+
+```{note}
+Wait for about 10 minutes to make sure the DNS records actually resolves properly.
+```
+
+8. Set `proxy.https.enabled` to `true` in the cluster config file so we can get HTTPS.
+
+9. Finally run the deployer again with 
+
+```bash
+python3 deployer deploy <cluster_name>
+```
+
+This last run should setup HTTPS and finally run a test suite.

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -123,7 +123,9 @@ But validation will not pass until this next section is done.
 
 ### Apply workaround to run CoreDNS on the master node
 
-More details on this [issue](https://github.com/kubernetes/kops/issues/11199)
+```{seealso}
+More details [in this issue](https://github.com/kubernetes/kops/issues/11199)
+```
 
 1. After the failed validation finished (you can run these command in another terminal 
 if you are impatient ;-) patch CoreDNS with

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -46,6 +46,7 @@ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
 ``` bash
 export KOPS_STATE_STORE=s3://2i2c-<cluster-name>-kops-state
 aws s3 mb $KOPS_STATE_STORE --region <region>
+aws s3api put-bucket-versioning --bucket $KOPS_STATE_STORE --versioning-configuration Status=Enabled
 ```
 
 ```{note}

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -100,7 +100,7 @@ You will need to relocate and encrypt the private key before pushing your change
 repository.
 ```
 
-3. Build the cluster with (notice that you are passing the ssh public key you just 
+3. Build the cluster with the following command (notice that you are passing the ssh public key you just 
 created in the previous step)
 
 ```bash

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -92,8 +92,6 @@ kops create -f <cluster_name>.kops.yaml
 
 ```bash
 ssh-keygen -f <cluster-name>.key
-mv ssh-key <cluster_name>.key
-mv ssh-key.pub <cluster_name>.key.pub
 ```
 
 3. Build the cluster with the following command (notice that you are passing the ssh public key you just 
@@ -120,7 +118,6 @@ After creating the cluster, you will need to relocate the public and private key
 
 ```bash
 mv <cluster_name>.key ssh-keys/<cluster_name>.key
-mv <cluster_name>.key.pub ssh-keys/<cluster_name>.key.pub
 ```
 
 and encrypt the private key with
@@ -130,6 +127,10 @@ sops -i -e ssh-keys/<cluster_name>.key
 ```
 
 before pushing your changes to the repository.
+
+```{note}
+You can always regenerate the public key with `ssh-keygen -y -f <cluster-name>.key`
+```
 
 ### Apply workaround to run CoreDNS on the master node
 

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -19,8 +19,7 @@ discussions outlined in [#431](https://github.com/2i2c-org/pilot-hubs/issues/431
 local environment and prepare `sops` to encrypt and decrypt files.
 
 2. Install the awscli tool (you can use pip or conda to install it in the environment)
-and configure it to use the provided AWS user credentials. Follow this
-[guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config)
+and configure it to use the provided AWS user credentials. [Follow this guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config)
 for a quick configuration process.
 
 ```{note}

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -107,14 +107,11 @@ The `--admin` at the end will modify your `~/.kube/config` file to point to the 
 cluster.
 ```
 
-If everything went as expected, the cluster will be created after some minutes, and you 
-should be able to validate it with
+If everything went as expected, the cluster will be created after some minutes.
 
-```bash
-kops validate cluster --wait 10m
+```{note}
+If you try to validate the cluster, validation will not pass until this next section is done.
 ```
-
-But validation will not pass until this next section is done.
 
 4. Relocate and encrypt the generated keys
 
@@ -139,14 +136,19 @@ before pushing your changes to the repository.
 More details [in this issue](https://github.com/kubernetes/kops/issues/11199)
 ```
 
-1. After the failed validation finished (you can run these commands in another terminal 
-if you are impatient ;-) patch CoreDNS with
+1. Patch CoreDNS with the following two commands
 
 ```bash
 kubectl -n kube-system patch deployment kube-dns --type json --patch '[{"op": "add", "path": "/spec/template/spec/tolerations", "value": [{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]}]'
 deployment.apps/kube-dns patched
 
 kubectl -n kube-system patch deployment kube-dns-autoscaler --type json --patch '[{"op": "add", "path": "/spec/template/spec/tolerations", "value": [{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]}]'
+```
+
+2. After applying those patches, you should be able to validate the cluster with
+
+```bash
+kops validate cluster --wait 10m
 ```
 
 ### Create an EFS for your cluster

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -28,7 +28,7 @@ privileges. We will probably explore fine-graining the permissions actually need
 in the short-term.
 ```
 
-3. Export some helpful AWS environment variables (because "aws configure" doesn't export
+3. Export some helpful AWS environment variables (because `aws configure` doesn't export
 these environments vars for kops to use, so we do it manually).
 
 ```bash

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -49,8 +49,7 @@ aws s3 mb $KOPS_STATE_STORE --region <region>
 ```
 
 ```{note}
-Kops [recommends](https://kops.sigs.k8s.io/getting_started/aws/#cluster-state-storage)
-versioning the S3 bucket in case you ever need to revert or recover a previous state
+Kops [recommends versioning the S3 bucket](https://kops.sigs.k8s.io/getting_started/aws/#cluster-state-storage) in case you ever need to revert or recover a previous state
 store.
 ```
 

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -145,7 +145,7 @@ kubectl -n kube-system patch deployment kube-dns-autoscaler --type json --patch 
 2. Create an [EFS](https://aws.amazon.com/efs/) file system for this hub with
 
 ```bash
-python3 setup-efs.py <cluster_name>hub.k8s.local us-east-2
+python3 setup-efs.py <cluster_name>hub.k8s.local <region-of-cluster>
 ```
 
 This will output an fs-<xxxxxxxx> id. You should use that value 

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -211,6 +211,7 @@ Create a CNAME record for `staging.foo.2i2c.cloud` and point it to the AWS exter
 
 ```{note}
 Wait for about 10 minutes to make sure the DNS records actually resolves properly.
+If you are deploying `prod` hub as well, you will need to repeat this step for `prod`.
 ```
 
 8. Set `proxy.https.enabled` to `true` in the cluster config file so we can get HTTPS.

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -56,8 +56,7 @@ store.
 ### Create and render a kops config file
 
 You can use 
-[one](https://github.com/2i2c-org/pilot-hubs/blob/master/kops/farallon.jsonnet) of the
-existing [jsonnet](https://jsonnet.org/) specifications as a "template" for your cluster.
+of the existing [jsonnet](https://jsonnet.org/) specifications as a "template" for your cluster (for example, [here is the Farallon Institute specification](https://github.com/2i2c-org/pilot-hubs/blob/master/kops/farallon.jsonnet)).
 You may need to tweak zones, names and instances, the rest is boilerplate to create a
 kops-based cluster accordingly to some specification already outlined in 
 [#28](https://github.com/2i2c-org/pangeo-hubs/issues/28). Once you have your jsonnet

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -91,7 +91,7 @@ kops create -f <cluster_name>.kops.yaml
 2. You will need to a ssh key pair before actually creating the cluster
 
 ```bash
-ssh-keygen -f ssh-key
+ssh-keygen -f <cluster-name>.key
 mv ssh-key <cluster_name>.key
 mv ssh-key.pub <cluster_name>.key.pub
 ```

--- a/docs/howto/operate/add-aws-hub.md
+++ b/docs/howto/operate/add-aws-hub.md
@@ -44,7 +44,7 @@ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
 [state](https://kops.sigs.k8s.io/state/).
 
 ``` bash
-export KOPS_STATE_STORE=s3://<2i2c>-<hub-name>-kops-state
+export KOPS_STATE_STORE=s3://2i2c-<hub-name>-kops-state
 aws s3 mb $KOPS_STATE_STORE --region <region>
 ```
 

--- a/docs/howto/operate/index.md
+++ b/docs/howto/operate/index.md
@@ -16,4 +16,5 @@ manual-deploy.md
 grafana.md
 node-administration.md
 move-hub.md
+add-aws-hub.md
 ```


### PR DESCRIPTION
This is the first iteration in the creation of a how-to guide describing how you can manually set up an AWS kops-based cluster and use our deployer to manually deploy a new hub on top of it.

More details in the commit message (and in the document itself) :wink:

Draft PR for now!