### PR TITLE
Tune-up cloudbank demo hub for UCB Workshop

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -206,6 +206,15 @@ hubs:
         database_name: database-demo
     config:
       jupyterhub:
+        prePuller:
+          continuous:
+            enabled: true
+          hook:
+            enabled: true
+        singleuser:
+          memory:
+            guarantee: 512M
+            limit: 1G
         custom:
           homepage:
             templateVars:


### PR DESCRIPTION
UC Berkeley is running their national data science teaching
workshop this week, and will be using our demo hub for
most of their classes. To ensure smooth use, we:

1. Setup pre-puller. We'll also increase minimum size of the cluster
   separately
2. Increase resource guarantees to prevent possibility of users running
   out of RAM