### PR TITLE
Remove max user limits on cloudbank demo hub

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -242,9 +242,6 @@ hubs:
               - georgiana.dolocan@gmail.com
               - ericvd@gmail.com
               - sean.smorris@berkeley.edu
-            JupyterHub:
-              # No more than 100 users at a time
-              active_server_limit: 100
         cull:
           # Cull after 30min of inactivity
           every: 300


### PR DESCRIPTION
Next 5 days, theres' a workshop going on

Follow-up https://github.com/2i2c-org/pilot-hubs/pull/468