### PR TITLE
Tweak daskhub config defaults

### DIFF
--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -13,6 +13,8 @@ basehub:
       hook:
         enabled: false
     singleuser:
+      # Almost everyone using dask by default wants JupyterLab
+      defaultUrl: /lab
       extraLabels:
          hub.jupyter.org/network-access-proxy-http: "true"
 

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -178,8 +178,8 @@ dask-gateway:
                     "environment": options.environment,
                 }
             return Options(
-                Integer("worker_cores", 2, min=1, max=16, label="Worker Cores"),
-                Float("worker_memory", 4, min=1, max=32, label="Worker Memory (GiB)"),
+                Integer("worker_cores", 2, min=1, label="Worker Cores"),
+                Float("worker_memory", 4, min=1, label="Worker Memory (GiB)"),
                 # The default image is set via DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE env variable
                 String("image", label="Image"),
                 Mapping("environment", {}, label="Environment Variables"),


### PR DESCRIPTION
- Currently, users have to set these manually, so limiting it
   to 32 prevents provisioning instances larger than that.
- Set daskhub default to /lab - orgs using dask mostly want to
  use lab as the default

Ref https://github.com/2i2c-org/pilot-hubs/issues/291#issuecomment-858075940