### PR TITLE
farallon: List authenticated users

### DIFF
--- a/config/hubs/farallon.cluster.yaml
+++ b/config/hubs/farallon.cluster.yaml
@@ -111,6 +111,20 @@ hubs:
             readinessProbe:
               enabled: false
             nodeSelector: {}
+            config:
+              Authenticator:
+                allowed_users: &users
+                  - yuvipanda
+                  - caitlinkroeger
+                  - cgentemann
+                  - choldgraf
+                  - DaisyShi19
+                  - GeorgianaElena
+                  - jeffdorman
+                  - marisolgr
+                  - trondkr
+                  - zbird21
+                admin_users: *users
             tolerations:
               - key:  "node-role.kubernetes.io/master"
                 effect: "NoSchedule"


### PR DESCRIPTION
In the older setup
(https://github.com/2i2c-org/pangeo-hubs/blob/5115e56a60da49513891d362daf52933c7186698/deployments/farallon/config/common.yaml#L13),
we used a GitHub org to control who can login. Our auth0 support
does not support GitHub org based access control yet - so
they are listed here.

For now, new users will need to be added via the JupyterHub UI:
https://pilot.2i2c.org/en/latest/admin/howto/manage-users.html

Ref https://github.com/2i2c-org/pilot-hubs/issues/368