### PR TITLE
Slight change to new hub template title

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-hub.md
+++ b/.github/ISSUE_TEMPLATE/new-hub.md
@@ -2,7 +2,7 @@
 name: "💻 New Hub"
 about: Creating a new hub for 2i2c to operate
 labels: "type: hub"
-title: "[Hub] - [Hub name]"
+title: "New Hub: [Hub name]"
 ---
 
 # Background


### PR DESCRIPTION
Issue categorizers should either be [Category] or Category:,
but this had a combo where it was [Category] -. Picking the
: variety, but we can use the [] variety instead too