### PR TITLE
Update CCSF logo

### DIFF
--- a/config/hubs/cloudbank.cluster.yaml
+++ b/config/hubs/cloudbank.cluster.yaml
@@ -64,7 +64,7 @@ hubs:
             templateVars:
               org:
                 name: City College SF
-                logo_url: https://www.ccsf.edu/sites/default/files/inline-images/asset-th-logo-black.png
+                logo_url: https://www.ccsf.edu/sites/default/files/inline-images/CCSF%20LOGO.png
                 url: https://www.ccsf.edu/
               designed_by:
                 name: 2i2c


### PR DESCRIPTION
This fixes the support request received via email yesterday: 
>  Hello,
   Thank you for your support with our 2i2c hub in connection with CCSF. I noticed that our hub-log is a bit distorted. 
         * The current image source links to a thumbnail: https://www.ccsf.edu/sites/default/files/inline-images/asset-th-logo-black.png 
         * Could you please update that source to the larger graphic for the logo: https://www.ccsf.edu/sites/default/files/inline-images/CCSF%20LOGO.png
   This seemed to address the issue when I changed the source in the browser console. Thank you for this cosmetic change! 🙂

