### PR TITLE
Make carbonplan hub more resilient - part 2

### DIFF
--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -22,11 +22,6 @@ hubs:
             - noresvport
             serverIP: fs-8a4e4f8d.efs.us-west-2.amazonaws.com
             baseShareName: /
-          shareCreator:
-            tolerations:
-            - key: node-role.kubernetes.io/master
-              operator: "Exists"
-              effect: "NoSchedule"
         jupyterhub:
           custom:
             homepage:
@@ -126,9 +121,6 @@ hubs:
                   cpu: 1
                   memory: 4Gi
               nodeSelector: {}
-              tolerations:
-                - key:  "node-role.kubernetes.io/master"
-                  effect: "NoSchedule"
             traefik:
               resources:
                 requests:
@@ -137,10 +129,6 @@ hubs:
                 limits:
                   cpu: 1
                   memory: 4Gi
-              nodeSelector: {}
-              tolerations:
-                - key:  "node-role.kubernetes.io/master"
-                  effect: "NoSchedule"
           hub:
             resources:
               requests:
@@ -156,14 +144,8 @@ hubs:
             readinessProbe:
               enabled: false
             nodeSelector: {}
-            tolerations:
-              - key:  "node-role.kubernetes.io/master"
-                effect: "NoSchedule"
       dask-gateway:
         traefik:
-          tolerations:
-            - key:  "node-role.kubernetes.io/master"
-              effect: "NoSchedule"
           resources:
             requests:
               cpu: 0.5
@@ -172,9 +154,6 @@ hubs:
               cpu: 2
               memory: 4Gi
         controller:
-          tolerations:
-            - key:  "node-role.kubernetes.io/master"
-              effect: "NoSchedule"
           resources:
             requests:
               cpu: 0.5
@@ -190,9 +169,6 @@ hubs:
             limits:
               cpu: 2
               memory: 4Gi
-          tolerations:
-            - key:  "node-role.kubernetes.io/master"
-              effect: "NoSchedule"
             # TODO: figure out a replacement for userLimits.
           extraConfig:
             idle: |

--- a/kops/carbonplan.jsonnet
+++ b/kops/carbonplan.jsonnet
@@ -18,7 +18,49 @@ local data = {
         },
         spec+: {
             // FIXME: Not sure if this is necessary?
-            configBase: "s3://2i2c-carbonplan-kops-state/%s" % data.cluster.metadata.name
+            configBase: "s3://2i2c-carbonplan-kops-state/%s" % data.cluster.metadata.name,
+
+            etcdClusters: [
+                {
+                    cpuRequest: "500m",
+                    etcdMembers: [
+                        {
+                            instanceGroup: "master",
+                            name: "a"
+                        },
+                        {
+                            instanceGroup: "master",
+                            name: "b"
+                        },
+                        {
+                            instanceGroup: "master",
+                            name: "c"
+                        }
+                    ],
+                    memoryRequest: "1Gi",
+                    name: "main"
+                },
+                {
+                    cpuRequest: "500m",
+                    etcdMembers: [
+
+                        {
+                            instanceGroup: "master",
+                            name: "a"
+                        },
+                        {
+                            instanceGroup: "master",
+                            name: "b"
+                        },
+                        {
+                            instanceGroup: "master",
+                            name: "c"
+                        }
+                    ],
+                    memoryRequest: "1Gi",
+                    name: "events"
+                }
+            ],
         },
         _config+:: {
             zone: zone,
@@ -33,16 +75,31 @@ local data = {
             name: "master"
         },
         spec+: {
-            machineType: "m5.2xlarge",
+            machineType: "m5.4xlarge",
+            subnets: [zone],
+            // CarbonPlan runs big jobs, so let's have a big node here
+            minSize: 1,
+            maxSize: 3,
+            role: "Master"
+        },
+    },
+    coreNodes: ig {
+        metadata+: {
+            labels+: {
+                "kops.k8s.io/cluster": data.cluster.metadata.name
+            },
+            name: "core"
+        },
+        spec+: {
+            machineType: "m5.xlarge",
             subnets: [zone],
             nodeLabels+: {
                 "hub.jupyter.org/node-purpose": "core",
                 "k8s.dask.org/node-purpose": "core"
             },
-            // CarbonPlan runs big jobs, so let's be resilient here
-            minSize: 3,
+            minSize: 2,
             maxSize: 6,
-            role: "Master"
+            role: "Node"
         },
     },
     notebookNodes: [
@@ -98,5 +155,6 @@ local data = {
 
 [
     data.cluster,
-    data.master
+    data.master,
+    data.coreNodes
 ] + data.notebookNodes + data.daskNodes

--- a/kops/libsonnet/cluster.jsonnet
+++ b/kops/libsonnet/cluster.jsonnet
@@ -51,10 +51,8 @@
         authorization: {
             rbac: {}
         },
-        dns: {
-            kubeDNS: {
-                provider: "CoreDNS"
-            }
+        kubeDNS: {
+            provider: "CoreDNS"
         },
         channel: "stable",
         cloudProvider: "aws",


### PR DESCRIPTION
- We had another outage caused by resource exhaustion
  on the k8s master nodes. This commit separates the k8s
  master nodes from the hub control plane, giving them
  more room to breathe
- We had a single-node etcd cluster without a lot of
  resource commitments. It's now bumped up to 3 nodes,
  with more resources.
- Actually use coredns for our clusters
  A typo in the schema meant we were using legacy kube-dns,
  which was causing problems - DNS saturation seems to be
  a problem with the earlier kube-dns in carbonplan
- Increase the node size of our k8s master nodes for now -
      we can tone this down later if necessary