### PR TITLE
Specify dep version, otherwise improper constraint error

### DIFF
--- a/hub-templates/daskhub/Chart.yaml
+++ b/hub-templates/daskhub/Chart.yaml
@@ -5,6 +5,7 @@ name: daskhub
 version: "0.1.0"
 dependencies:
  - name: basehub
+   version: "0.1.0"
    repository: file://../basehub
  - name: dask-gateway
    version: "0.9.0"


### PR DESCRIPTION
Somehow, without this, helm dependency's upgrade [fails](https://github.com/2i2c-org/pilot-hubs/runs/3111724001) with:

```
Error: dependency "basehub" has an invalid version/constraint format: improper constraint: 
...Successfully got an update from the "https://dask.org/dask-gateway-helm-repo/" chart repository
Error: Process completed with exit code 1.
``` 

It was failing even before the logo modification deployment attempt and I tracked it down to this commit: https://github.com/2i2c-org/pilot-hubs/commit/d9d79370abe2f2ef046c510e502f1172903b7edd

It says that the version is obsolete, but I found this piece of info here (https://kb.novaordis.com/index.php/Helm_Dependencies):
```
Note that even if it seems unnecessary, as an unpacked chart can have just one and only one version, the "version" information in the dependent's chart is actually required, and it is matched against ../b/Chart.yaml.

If the dependency declaration does not contain version, helm dependency update fails with:

helm dependency update ./a
[...]
Saving 1 charts
Save error occurred:  dependency b has an invalid version/constraint format: improper constraint:
Deleting newly downloaded charts, restoring pre-update state
Error: dependency b has an invalid version/constraint format: improper constraint:
```

cc @consideRatio, @yuvipanda :sunflower: 