### PR TITLE
Label nodes with their instancegroup name

### DIFF
--- a/kops/libsonnet/instancegroup.jsonnet
+++ b/kops/libsonnet/instancegroup.jsonnet
@@ -44,7 +44,9 @@ local makeCloudTaints(taints) = {
             "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/instance-type": $.spec.machineType
         } + makeCloudLabels(self.nodeLabels) + makeCloudTaints(self.taints),
         taints: [],
-        nodeLabels: {},
+        nodeLabels: {
+            "kops.k8s.io/instance-group": $.metadata.name
+        },
         machineType: "",
         maxSize: 20,
         minSize: 0,


### PR DESCRIPTION
https://github.com/jupyterhub/grafana-dashboards
needs some label to distinguish different node pools,
and kops doesn't seem to add one by default.