### PR TITLE
Bump resource requests for prometheus

### DIFF
--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -9,10 +9,10 @@ support:
         resources:
           requests:
             cpu: 1
-            memory: 6Gi
+            memory: 4Gi
           limits:
             cpu: 4
-            memory: 12Gi
+            memory: 8Gi
     grafana:
       ingress:
         hosts:

--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -4,6 +4,15 @@ kubeconfig:
   file: secrets/carbonplan.yaml
 support:
   config:
+    prometheus:
+      server:
+        resources:
+          requests:
+            cpu: 1
+            memory: 6Gi
+          limits:
+            cpu: 4
+            memory: 12Gi
     grafana:
       ingress:
         hosts:


### PR DESCRIPTION
Earlier limits were too little, causing the server
to crash.