### PR TITLE
Expose grafana as a service on COESSING hub

### DIFF
--- a/config/hubs/pangeo-181919.cluster.yaml
+++ b/config/hubs/pangeo-181919.cluster.yaml
@@ -5,16 +5,6 @@ gcp:
   project: pangeo-181919
   cluster: pangeo-hubs-cluster
   zone: us-central1-b
-support:
-  config:
-    grafana:
-      ingress:
-        hosts:
-          - grafana.pangeo.2i2c.cloud
-        tls:
-          - secretName: grafana-tls
-            hosts:
-              - grafana.pangeo.2i2c.cloud
 hubs:
   - name: coessing
     domain: coessing.pangeo.2i2c.cloud
@@ -55,6 +45,9 @@ hubs:
                   - choldgraf@gmail.com
                   - georgiana.dolocan@gmail.com
                 admin_users: *coessing_users
+            services:
+              grafana:
+                url: http://grafana
           singleuser:
             image:
               name: quay.io/2i2c/coessing-image
@@ -75,3 +68,11 @@ hubs:
               memory:
                 request: 1G
                 limit: 2G
+      grafana:
+        grafana.ini:
+          server:
+            domain: coessing.pangeo.2i2c.cloud
+            root_url: 'https://%(domain)s/services/grafana'
+            serve_from_sub_path: true
+            enable_gzip: true
+            router_logging: true

--- a/config/hubs/pangeo-181919.cluster.yaml
+++ b/config/hubs/pangeo-181919.cluster.yaml
@@ -68,11 +68,13 @@ hubs:
               memory:
                 request: 1G
                 limit: 2G
-      grafana:
-        grafana.ini:
-          server:
-            domain: coessing.pangeo.2i2c.cloud
-            root_url: 'https://%(domain)s/services/grafana'
-            serve_from_sub_path: true
-            enable_gzip: true
-            router_logging: true
+      support:
+        config:
+          grafana:
+            grafana.ini:
+              server:
+                domain: coessing.pangeo.2i2c.cloud
+                root_url: 'https://%(domain)s/services/grafana'
+                serve_from_sub_path: true
+                enable_gzip: true
+                router_logging: true


### PR DESCRIPTION
Make grafana available at HUB_URL/services/grafana
instead of at grafana.HUB_URL
Minimises the need for extra A records in DNS.