### PR TITLE
Make sure to pull in the cert-manager repo in CI

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -13,6 +13,8 @@ runs:
       shell: bash
     - name: Fetch helm charts
       run: |
+        helm repo add jetstack https://charts.jetstack.io
+        helm repo update
         cd hub-templates
         helm dep up basehub
         helm dep up daskhub

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -80,7 +80,18 @@ class Cluster:
                     json.dump(config, f, indent=4)
 
     def deploy_support(self):
+        cert_manager_url = 'https://charts.jetstack.io'
         cert_manager_version = 'v1.3.1'
+
+        print("Adding cert-manager chart repo...")
+        subprocess.check_call([
+            'helm', 'repo', 'add', 'jetstack', cert_manager_url,
+        ])
+
+        print("Updating cert-manager chart repo...")
+        subprocess.check_call([
+            'helm', 'repo', 'update',
+        ])
 
         print("Provisioning cert-manager...")
         subprocess.check_call([

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -80,18 +80,7 @@ class Cluster:
                     json.dump(config, f, indent=4)
 
     def deploy_support(self):
-        cert_manager_url = 'https://charts.jetstack.io'
         cert_manager_version = 'v1.3.1'
-
-        print("Adding cert-manager chart repo...")
-        subprocess.check_call([
-            'helm', 'repo', 'add', 'jetstack', cert_manager_url,
-        ])
-
-        print("Updating cert-manager chart repo...")
-        subprocess.check_call([
-            'helm', 'repo', 'update',
-        ])
 
         print("Provisioning cert-manager...")
         subprocess.check_call([


### PR DESCRIPTION
Merging #456 broke CI since we don't pull the cert-manager chart in automatically. This PR adds the required `helm repo add ...` and `helm repo update` commands in the GitHub `action.yaml` file next to where we update `basehub` and `daskhub`.