### PR TITLE
Add actions for incident reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident-report.md
+++ b/.github/ISSUE_TEMPLATE/incident-report.md
@@ -58,3 +58,9 @@ These are only sample subheadings. Every action item should have a GitHub issue
 
 1. {{ summary }} [link to github issue]
 2. {{ summary }} [link to github issue]
+
+# Actions
+
+- [ ] Incident has been dealt with or is over
+- [ ] Sections above are filled out
+- [ ] All actionable items above have linked GitHub Issues


### PR DESCRIPTION
In https://github.com/2i2c-org/pilot-hubs/issues/524 we identified the need for some specific "actions" to take in writing incident reports so that we know when to close the reports. This adds such a list to our incident report template.