### PR TITLE
Add OHW hub

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -96,6 +96,49 @@ hubs:
                   - choldgraf@gmail.com
                   - georgiana.dolocan@gmail.com
                 admin_users: *dask_staging_users
+  - name: ohw
+    domain: ohw.pilot.2i2c.cloud
+    template: daskhub
+    auth0:
+      connection: github
+    config:
+      basehub:
+        jupyterhub:
+          singleuser:
+            image:
+              name: uwhackweeks/oceanhackweek
+              tag: 28d1c7b
+          custom:
+            cloudResources:
+              provider: gcp
+              gcp:
+                projectId: two-eye-two-see
+              scratchBucket:
+                enabled: true
+            homepage:
+              templateVars:
+                org:
+                  name: "Ocean Hack Week"
+                  logo_url: https://pbs.twimg.com/profile_images/1295457048830844935/RN-i02MO_400x400.png
+                  url: https://oceanhackweek.github.io/
+                designed_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+                operated_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+                funded_by:
+                  name: 2i2c
+                  url: https://2i2c.org
+          hub:
+            config:
+              Authenticator:
+                allowed_users: &ohw_users
+                  - yuvipanda
+                  - choldgraf
+                  - GeorgianaElena
+                  - ocefpaf
+                admin_users: *ohw_users
   - name: justiceinnovationlab
     domain: justiceinnovationlab.pilot.2i2c.cloud
     template: basehub

--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -118,8 +118,8 @@ hubs:
             homepage:
               templateVars:
                 org:
-                  name: "Ocean Hack Week"
-                  logo_url: https://pbs.twimg.com/profile_images/1295457048830844935/RN-i02MO_400x400.png
+                  name: Ocean Hack Week
+                  logo_url: https://avatars.githubusercontent.com/u/33128979
                   url: https://oceanhackweek.github.io/
                 designed_by:
                   name: 2i2c


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/pilot-hubs/issues/549

This was already deployed and running at https://ohw.pilot.2i2c.cloud/

### Note:
For whatever reason, using the [Twitter profile image of OHW](https://pbs.twimg.com/profile_images/1295457048830844935/RN-i02MO_400x400.png) as the hub logo, it doesn't work.
**P.S.** We have another hub https://earthlab.pilot.2i2c.cloud that uses a Twitter image and that doesn't work either.

### Update:
Used the GitHub image of the org for the logo and now it shows