### PR TITLE
Deploy some more hub automatically

### DIFF
--- a/.github/workflows/deploy-carbonplan.yaml
+++ b/.github/workflows/deploy-carbonplan.yaml
@@ -1,0 +1,30 @@
+name: Deploy and Test carbonplan hub
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - deployer/**
+      - hub-templates/**
+      - requirements.txt
+      - dev-requirements.txt
+      - config/secrets.yaml
+      - config/hubs/carbonplan.cluster.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          # This is used for KMS only
+          project_id: two-eye-two-see
+          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+          export_default_credentials: true
+      - uses: azure/setup-helm@v1
+      - uses: mdgreenwald/mozilla-sops-action@v1
+      - uses: ./.github/actions/deploy
+        with:
+          cluster: 'carbonplan'

--- a/.github/workflows/deploy-meom-ige.yaml
+++ b/.github/workflows/deploy-meom-ige.yaml
@@ -1,0 +1,30 @@
+name: Deploy and Test meom-ige hub
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - deployer/**
+      - hub-templates/**
+      - requirements.txt
+      - dev-requirements.txt
+      - config/secrets.yaml
+      - config/hubs/meom-ige.cluster.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          # This is used for KMS only
+          project_id: two-eye-two-see
+          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+          export_default_credentials: true
+      - uses: azure/setup-helm@v1
+      - uses: mdgreenwald/mozilla-sops-action@v1
+      - uses: ./.github/actions/deploy
+        with:
+          cluster: 'meom-ige'

--- a/.github/workflows/deploy-pangeo-181919.yaml
+++ b/.github/workflows/deploy-pangeo-181919.yaml
@@ -1,0 +1,30 @@
+name: Deploy and Test pangeo hub
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - deployer/**
+      - hub-templates/**
+      - requirements.txt
+      - dev-requirements.txt
+      - config/secrets.yaml
+      - config/hubs/pangeo-181919.cluster.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          # This is used for KMS only
+          project_id: two-eye-two-see
+          service_account_key: ${{ secrets.GCP_KMS_DECRYPTOR_KEY }}
+          export_default_credentials: true
+      - uses: azure/setup-helm@v1
+      - uses: mdgreenwald/mozilla-sops-action@v1
+      - uses: ./.github/actions/deploy
+        with:
+          cluster: 'pangeo-181919'

--- a/.github/workflows/deploy-pangeo-181919.yaml
+++ b/.github/workflows/deploy-pangeo-181919.yaml
@@ -1,4 +1,4 @@
-name: Deploy and Test pangeo hub
+name: Deploy and Test COESSING hub
 
 on:
   push:


### PR DESCRIPTION
Ref https://github.com/2i2c-org/pilot-hubs/issues/507

I'm worried that incomplete tests might leave notebook
nodes running, but the culler should take care of those? We
must verify this.

Added automatic deployment for everything except farallon
and openscapes hubs - those are using `kops` and I think
their kubernetes credentials will have expired. #381 
tracks a fix.

 Once this is merged, PRs like https://github.com/2i2c-org/pilot-hubs/pull/580
can be deployed without needing a local setup