### PR TITLE
Provision a separate nodepool for ohw

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -115,8 +115,8 @@ hubs:
         jupyterhub:
           singleuser:
             image:
-              name: uwhackweeks/oceanhackweek
-              tag: 28d1c7b
+              name: ghcr.io/oceanhackweek/jupyer-image
+              tag: 9efd4fb
             nodeSelector:
                 2i2c.org/community: ohw
             memory:

--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -102,12 +102,23 @@ hubs:
     auth0:
       connection: github
     config:
+      dask-gateway:
+        gateway:
+          backend:
+            scheduler:
+              nodeSelector:
+                2i2c.org/community: ohw
+            worker:
+              nodeSelector:
+                2i2c.org/community: ohw
       basehub:
         jupyterhub:
           singleuser:
             image:
               name: uwhackweeks/oceanhackweek
               tag: 28d1c7b
+            nodeSelector:
+                2i2c.org/community: ohw
             memory:
               # Increase memory alloted during the workshop
               #  https://github.com/2i2c-org/pilot-hubs/issues/549#issuecomment-891264570

--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -113,6 +113,9 @@ hubs:
                 2i2c.org/community: ohw
       basehub:
         jupyterhub:
+          prePuller:
+            continuous:
+              enabled: true
           singleuser:
             image:
               name: ghcr.io/oceanhackweek/jupyer-image

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -134,11 +134,11 @@ resource "google_container_node_pool" "notebook" {
       # config connector and completely hide all node metadata from user pods
       node_metadata = var.config_connector_enabled ? "GKE_METADATA_SERVER" : "SECURE"
     }
-    labels = {
+    labels = merge({
       # Notebook pods and dask schedulers can exist here
       "hub.jupyter.org/node-purpose" = "user",
       "k8s.dask.org/node-purpose"    = "scheduler",
-    }
+    }, each.value.labels)
 
     taint = [{
       key    = "hub.jupyter.org_dedicated"
@@ -199,9 +199,9 @@ resource "google_container_node_pool" "dask_worker" {
       # config connector and completely hide all node metadata from user pods
       node_metadata = var.config_connector_enabled ? "GKE_METADATA_SERVER" : "SECURE"
     }
-    labels = {
+    labels = merge({
       "k8s.dask.org/node-purpose" = "worker",
-    }
+    }, each.value.labels)
 
     taint = [{
       key    = "k8s.dask.org_dedicated"

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -13,16 +13,34 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "e2-highmem-4"
+    machine_type : "e2-highmem-4",
+    labels: { }
   },
+  "ohw": {
+    min: 0,
+    max: 50,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "ohw"
+    },
+  }
 }
 
 dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-4"
+    machine_type : "e2-highmem-4",
+    labels: { }
   },
+  "ohw": {
+    min: 0,
+    max: 100,
+    machine_type: "n1-highmem-4",
+    labels: {
+      "2i2c.org/community": "ohw"
+    },
+  }
 }
 
 user_buckets = []

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -24,13 +24,13 @@ variable "project_id" {
 }
 
 variable "notebook_nodes" {
-  type        = map(map(string))
+  type        = map(object({ min : number, max : number, machine_type : string, labels : map(string) }))
   description = "Notebook node pools to create"
   default     = {}
 }
 
 variable "dask_nodes" {
-  type        = map(map(string))
+  type        = map(object({ min : number, max : number, machine_type : string, labels : map(string) }))
   description = "Dask node pools to create. Defaults to notebook_nodes"
   default     = {}
 }


### PR DESCRIPTION
- Helps provide dedicated resources for the hackathon
- Lays the groundwork for keeping a warm pool of nodes for
  the hackathon.
- Uses n1- machines rather than e2- machines. We should move
  everything to n1 - the sustained use discount is worth a
  lot of money
- Put ohw notebook and dask pods on the new node pool
- Enable continuous image prepuller, so new nodes coming up
   will automatically pull the image. The notebook image tag is also
   explicitly set so the pre-puller can bring it in.

Ref https://github.com/2i2c-org/pilot-hubs/issues/549