### PR TITLE
[BUGFIX] Backwards condition for enabling private nodes

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -17,7 +17,7 @@ resource "google_container_cluster" "cluster" {
   // Dynamically provision the private cluster config when deploying a
   // private cluster
   dynamic "private_cluster_config" {
-    for_each = var.enable_private_cluster == "" ? [] : [1]
+    for_each = var.enable_private_cluster ? [1] : []
 
     content {
       // Decide if this CIDR block is sensible or not


### PR DESCRIPTION
Realised I'd got a condition backwards in the private nodes terraform config. This PR fixes it.

I realised this while checking #579 gave a noop output and it did not 😳  