### PR TITLE
Add tfvars file for pangeo-181919 cluster

### DIFF
--- a/terraform/gcp/projects/pangeo-181919.tfvars
+++ b/terraform/gcp/projects/pangeo-181919.tfvars
@@ -1,0 +1,32 @@
+prefix                 = "pangeo-hubs"
+project_id             = "pangeo-181919"
+
+core_node_machine_type = "n1-highmem-4"
+
+# Multi-tenant cluster, network policy is required to enforce separation between hubs
+enable_network_policy    = true
+
+# Some hubs want a storage bucket, so we need to have config connector enabled
+config_connector_enabled = true
+
+notebook_nodes = {
+  "user" : {
+    min : 0,
+    max : 20,
+    machine_type : "n1-highmem-4"
+    labels : {}
+  },
+}
+
+dask_nodes = {
+  "worker" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-highmem-4"
+    labels : {}
+  },
+}
+
+user_buckets = [
+  "scratch"
+]


### PR DESCRIPTION
I had forgotten to add the tfvars file for the COESSING cluster (in the original Pangeo project) to the repo. Adding it now so our repo matches our cloud state.