### PR TITLE
Add deployer key for meom-ige cluster

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -427,4 +427,4 @@ class Hub:
                     print("Health check failed!", file=sys.stderr)
                     sys.exit(exit_code)
                 else:
-                    print("Helath check succeeded!")
+                    print("Health check succeeded!")

--- a/secrets/meom.json
+++ b/secrets/meom.json
@@ -1,0 +1,30 @@
+{
+	"type": "ENC[AES256_GCM,data:jNwbQW9dcvm3b+SOcHkn,iv:ihTmC8qpzvhggLVvE01p3QXKyTqrEtbsLb6ol0DqaJ8=,tag:HQwH0NpGK+3QFRmoUdlGtg==,type:str]",
+	"project_id": "ENC[AES256_GCM,data:EdLC95xgY/rChVG7Gw==,iv:5fJnvs7OeDMJYAHpR8eR0oWw2JjrCeJQ7IA3+XRbuC0=,tag:1ySiocy9ArzlBPqoT2BF+g==,type:str]",
+	"private_key_id": "ENC[AES256_GCM,data:IFeOBQp8S8PIrCzBCH4y9N5G86Ui+qa7sY4D6VCR2p2Oj5uuDinipw==,iv:c0qBGg9knPKSHgemQsqtR/nXlKAqy4xlgqnU6St1VmY=,tag:TiVEauSFDjnsJ4HmgIZyqw==,type:str]",
+	"private_key": "ENC[AES256_GCM,data:hd1dgtHGhi+ivlRFlirglLwR8+aZBuqa9+E6bVR82TNzC71wyb66U/rz/pO5ZCN/X3tHbThS3Ca7fQP6ejCOhbYaPZmLDoQQE5I16l5YHZ5BW3hABkiFrjwmEB6vi/zRoYBSq6ozNugySzL99Jt+gZAALPcZ+C3jOV1Sn/s0u8Wc+QyfYhxnQB/YWERttslY9iC2qb9my3hCuxGfesAUsHZGVUrG4VeFZYCdKYjX1z6by8RrOTbGr/RtAK6xa8IpJxtguWaBVkA3K0bAL34qDExUzqdBwtLXvFL2rX0G0VALYfdG16M8HRyLLAk7UindTezlPSrEiB1p3cHsu8IAyMRtX2gn0m/tGGDOT9UbTu4rQZfegw5A0bbbHjJBl0agyeprtiBZkLkDI+ahCibFWpDgAoeD5FHj++6Jl/2F4A+tHjKNQAzbRIl86TSESCA8o2rVGlUp4zrMjPUGOCE02G0oSL02FRWdJAsKckAdS1DtXDF9xSbL2CVqy1dRUCT1zZOg5VtvbbmHypBSZFgFT+j3SN8VwiP7O/Nr/sGTdmeXc6Bzj4I1wC6t5vmiXTpTBsNfsQeYBhCUgULxQduArLJh5i+WNWeEI9OVUo59aOat3DDtk+BHzCqn6iz+Dubg6dZ8w9ThbEVPuceGT+QscwkXspRMx+udaCKCYzdA21i3QwIif9ayVWs8Pdu++Ja6Fj+FAces/J+30t41WBW6ezz8c+MRpR+nzhWIxeJ21t4JVx39wWSBe6DjNhvd66Y/l7TAGsV63CDVg5FG4vAMiz+Yc+nj5/KuM0KLkep20wTVGhXLkw3Bqv2GWyQpwrwuYk2JiBUmlnqogX2FYLNNU+BWNRV77FNGUVgnfs6j+TgNnpG3I0k8FXSF0AiS7wPO5IDkvznBXswDIOjl7kZyBlfuHuZANshzAqJqOdNDycjgUh2v8rfnlYwgEFJRa/iK4WFzmtOT9OtQ9Q3YT71iPqQ5b0cYyZNAA9iUzeQB8xs7OUkLYPxB9E4FeYIQwSyU/floyIAupsVgJD4sTuxa/mb4DM32LydF4JOWJhuUiWexjrVQGibDCfLOsCaq5kSvuob6j2pFZSbXg6LbC2c/G+4cz+S2ReAKUNfQWkc13/lYDPq+H4nCTFo0KaZh1H54dZZ8MjmCobxUEhrsVrF25eNxSp9S5g3F5NW9cw10KMtsWaglWszaiffXm3qmycwIx5jjV03rftz/BXvyVcMygBYqYZ28cTTwhMGdRK8QHjtPgjfumqzisPiCs8zwNZC2wqNWRcgf/a4257sKSraJjGxCxVS/JPp7QEmfNWSBU5agWK5oUXztNaBkY8uYAk4EP3oEVC3hf0+33gyDuHyOdR2mKzdlmgnDuCD10BrSL49IYbFW93LFHZfbqMvPa4ssO64gZ8K1ve4qF1Ff0a24EVojc8tHoFmu3O+hER/FbHbjbP7NV7rXDTivc0ceD1vOVHLqauYelJ1yD+8mkR+MUx1nT2eNMna8U9xkFG4L2Bcf6JDIRnsulEIfUkkbxDrHAZXselfHFFJm6PXk+tPK1RFMI/wOiH0BF1aWbBj8NPPzWIyV1DvhMaEQpS/jde79h2R9zkk0EIL/2TgAT83ajhcpA50xQUT5U+c0qKhCxZZylSwA4EELf5ZsjtnZEkbGFwjw6vA8ozalKO8ip4qSXa6BUWTXHPWQ34AZyycvucQR0r8spf5LKyMd4kQoPXMz3bl2qe3RU4cupa6H5C/OvWsFDm1roDpCZLoQ+N+o/KYtPyWUPnYiQvfkez4dLeNrAifyzZgWkQfnM6xsw0KQ4sOBwc1OKuI42/bf9YZD76Acgbh7llgkzo2t+M+NFrzTUZfYu6vyoTz+0apXNvW8n2myeILDJixwdWsrQUgb9sXSGODPq7L3Bx2Rly+//G90Of7MFOG+vk1c8aotYCIdJUH4Rk78MsvTPJ5nQEIqfp8ksfULD0fbqLkcMoy3iVptf4azIu+0Tjy2qJduEQUVGg/FmMebb5C7azC+SK0sBtyvJ2YUklv7r6v0WxE7ZbPOpt3GE4Dea8fpkwmdXDrLBq/1WN7J7OQYBH8BpLCAe9pRhZo4NkdFEtjrqmafWUC64QwR3Lz0I+UtjERxfeRsTdX9hzY0LizGtg2cL5lb3MZXpIKZP1SxdtVDW7ItRJvuO3Kk4A4n7SopyjxgL+/5lJRyZxVlScoqrT+A+gkSeq1rIRinQv/tPX/+lEeXgexTseeUuEpU3vy2gcba/WejQ90K+GwQSRxL,iv:+fyhLY+e2F05MlJZxvlXWObrkzyGLSeFStmyZAwTRbY=,tag:Rwh7a6ZLGXmsJKJwbu/5rg==,type:str]",
+	"client_email": "ENC[AES256_GCM,data:6/C0GazMYHKOy9y51zx92hqm6Lx0OhU3kItIZc+FT6VFsfjM+yvHck7lX66KElatZesdzQ==,iv:jJFwmT4EW5O/OiOcuklNFQsXdg1L3hHbFQCH+oZSXdM=,tag:rlnp2I1HFxR4IYITj0MJJQ==,type:str]",
+	"client_id": "ENC[AES256_GCM,data:tSYokW7CkSM11YqwZY7HieCp1RyY,iv:0Fet0g3N/pfbXzB5hNxww6aiao3pXj9h/22wZg/3Zvc=,tag:r+YwjdQbqzlCwtYPXCZA+g==,type:str]",
+	"auth_uri": "ENC[AES256_GCM,data:jQaZHHW4rOX+ifzkyI/6zo1AFAbVpD+MhtwGJGLnQNfvi8BwVkcoa1w=,iv:mG8XXGKF5YPtGMzgXY3syqZkgDJqToKRddcmdBZmlx0=,tag:rJE8GYHaKvd5TNc2Z0BFng==,type:str]",
+	"token_uri": "ENC[AES256_GCM,data:r6XjwVYWD38zNjVRKIuYXAM2UHJuM9YC2iejTHkUyc7qmBI=,iv:p+w7xi+AZAt+pAglfSZ0I5PKROCN6mCk1C6+I5x90ik=,tag:nUh5btDpEEFORA2yzz/PhQ==,type:str]",
+	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:M4AHJXdIf26OScO5mKEpN1vv+yI5fVbxV+ALGJxbwNWrThl604wOCoa9,iv:Cey/Yunb53zs/pE5fasm/4gtg4XNxF47+aPj8AdSFxQ=,tag:Fy1HtbGu+wH0rRah0LZOGA==,type:str]",
+	"client_x509_cert_url": "ENC[AES256_GCM,data:Xq9BuSgjDZNM6fIgrG8FKGBwrCiIebISotOZ5rWqxtuFA4hkDJt6BzwcFhnIlPyqpDQVaJubGaY2Jksqf4fZ3+D9dULsCPxa9OXTdKKbfyWGw8EShsfWHcz7LUh1yVgSWGdFF3U2dUw=,iv:OoKx5528MCvZQyjVjmXDWstyYu0wbeK3BiffhocaKCY=,tag:C+M8e7YqpJ6M7qvya1rpIQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2021-08-06T08:51:13Z",
+				"enc": "CiQA4OM7eNHpo0/b6OyG3GTiAdjaNi1tdID/JfwPuQRVxt0g2s0SSQB6TpsYnNEWtwzANLqqHlzxE8c0T0Z/Y35P81QtDHnwjNRpPtqieXkWhMDT3xOXi8SHXNmiWjncqbXUW0hoHQIX79syoBgqfQA="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2021-08-06T08:51:14Z",
+		"mac": "ENC[AES256_GCM,data:eQs6ABB0Tl3nVzWtt36Bd4eZPVnHnjcInFCXsiML7wqojhXF3Cp00Fjo+oIPYYcyu6MeVNsOs2ICw8wNxzhUw5YtYSgTaL31PhuQ0be4CcHySTOnAsozpPowuUe2LbBCanQeNioNbwLug+NJcZU3Z7wlVDqTB+ggKdgw9WaiffM=,iv:pP/JEkNIJKwiwa7HRLWhuT+ONrvv4yZd0B3duuUV9mU=,tag:sJs9zmuZPy3/0KizVougZQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.1"
+	}
+}


### PR DESCRIPTION
This adds the deployer key (sops encrypted) for the meom-ige cluster to the repo for CI/CD workflows.

I extracted this from the meom-ige terraform workspace (there is also a meom workspace but that didn't have any outputs)