### PR TITLE
Remove carbonplan cluster from CI/CD matrix

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -26,7 +26,7 @@ jobs:
           # add its name to the list
           - 2i2c
           - cloudbank
-          - carbonplan
+          # - carbonplan  # We need to edit deployer to connect to aws before we can autodeploy carbonplan
           - meom-ige
           - pangeo-181919
 


### PR DESCRIPTION
Auto-deployment of carbonplan fails because deployer is not configured to handle aws tokens. We should manually deploy that cluster until the appropriate work has taken place in deployer.