### PR TITLE
Remove 'new-task' GitHub template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-task.md
+++ b/.github/ISSUE_TEMPLATE/new-task.md
@@ -1,9 +1,0 @@
----
-name: "✅ New Task"
-about: Tasks are concrete actions to be taken.
-labels: "type: task"
----
-
-# Summary
-
-<!-- What is the context needed to understand this task -->


### PR DESCRIPTION
Too many options here was a bit overwhelming for me. I
am not sure what a specific 'Task' label gives us over
just blank issues.