### PR TITLE
Shorten test traceback to avoid exposing secrets

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -411,20 +411,12 @@ class Hub:
 
                 hub_url = f'https://{self.spec["domain"]}'
 
-                # On failure, pytest prints out params to the test that failed.
-                # This can contain sensitive info - so we hide stderr
-                # FIXME: Try to be more granular here?
                 print("Running hub health check...")
-                with open(os.devnull, 'w') as dn, redirect_stderr(dn), redirect_stdout(dn):
-                    exit_code = pytest.main([
-                        "-q",
-                        "deployer/tests",
-                        "--hub-url", hub_url,
-                        "--api-token", service_api_token,
-                        "--hub-type", self.spec['template']
-                    ])
-                if exit_code != 0:
-                    print("Health check failed!", file=sys.stderr)
-                    sys.exit(exit_code)
-                else:
-                    print("Health check succeeded!")
+                pytest.main([
+                    "-q",
+                    "deployer/tests",
+                    "--hub-url", hub_url,
+                    "--api-token", service_api_token,
+                    "--hub-type", self.spec['template'],
+                    "--tb=short"
+                ])


### PR DESCRIPTION
This PR adds `--tb=short` to the `pytest` invocation in our hub health check which shortens the standard `pytest` output. Critically, this avoids printing sensitive params to the console. Example output below the fold.

fixes #585 

<details> <summary> Example output </summary>

```
Running hub health check...
F                                                                                  [100%]
======================================== FAILURES ========================================
____________________________________ test_hub_healthy ____________________________________
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/connector.py:999: in _create_direct_connection
    hosts = await asyncio.shield(host_resolved)
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/connector.py:865: in _resolve_host
    addrs = await self._resolver.resolve(host, port, family=self._family)
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/resolver.py:31: in resolve
    infos = await self._loop.getaddrinfo(
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/asyncio/base_events.py:825: in getaddrinfo
    return await self.run_in_executor(
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/concurrent/futures/thread.py:57: in run
    result = self.fn(*self.args, **self.kwargs)
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/socket.py:918: in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
E   socket.gaierror: [Errno 8] nodename nor servname provided, or not known

The above exception was the direct cause of the following exception:
deployer/tests/test_hub_health.py:73: in test_hub_healthy
    raise(e)
deployer/tests/test_hub_health.py:69: in test_hub_healthy
    await check_hub_health(hub_url, test_notebook_path, api_token)
deployer/tests/test_hub_health.py:33: in check_hub_health
    user = await hub.get_user(username)
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/jhub_client/api.py:39: in get_user
    async with self.session.get(self.api_url / 'users' / username) as response:
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/client.py:1117: in __aenter__
    self._resp = await self._coro
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/client.py:520: in _request
    conn = await self._connector.connect(
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/connector.py:535: in connect
    proto = await self._create_connection(req, traces, timeout)
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/connector.py:892: in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
/usr/local/Caskroom/miniconda/base/envs/pilot-hubs/lib/python3.8/site-packages/aiohttp/connector.py:1011: in _create_direct_connection
    raise ClientConnectorError(req.connection_key, exc) from exc
E   aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host staging.pangeo.2i2c.cloud:443 ssl:default [nodename nor servname provided, or not known]
---------------------------------- Captured stdout call ----------------------------------
Starting hub https://staging.pangeo.2i2c.cloud health validation...
Running dask_test_notebook.ipynb test notebook...
Hub https://staging.pangeo.2i2c.cloud not healthy! Stopping further deployments. Exception was Cannot connect to host staging.pangeo.2i2c.cloud:443 ssl:default [nodename nor servname provided, or not known].
================================ short test summary info =================================
FAILED deployer/tests/test_hub_health.py::test_hub_healthy - aiohttp.client_exceptions....
1 failed in 0.51s
```
</details>