### PR TITLE
Updated otter-grader to 2.2.5

### DIFF
--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -106,7 +106,7 @@ jupyterhub:
       hub.jupyter.org/node-purpose: user
     image:
       name: set_automatically_by_automation
-      tag: "135823b"
+      tag: "06e6a99"
     storage:
       type: static
       static:

--- a/images/user/requirements.txt
+++ b/images/user/requirements.txt
@@ -32,7 +32,7 @@ jupyterhub==1.3.0
 jupyter-rsession-proxy==1.2
 jupyter-tree-download==1.0.1
 ipywidgets==7.5.1
-otter-grader==2.1.7
+otter-grader==2.2.5
 datascience
 geojson
 folium


### PR DESCRIPTION
The otter-grader version is updated to 2.2.5, cloudbank and 2i2c cluster images a built and deployed, and the image tag
version is updated.

Fixes this issue [2i2c.org/pilot/86](https://github.com/2i2c-org/pilot/issues/86)