### PR TITLE
Updated otter-grader and bumped image tag

### DIFF
--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -106,7 +106,7 @@ jupyterhub:
       hub.jupyter.org/node-purpose: user
     image:
       name: set_automatically_by_automation
-      tag: "06e6a99"
+      tag: "b9cb08b"
     storage:
       type: static
       static:

--- a/images/user/requirements.txt
+++ b/images/user/requirements.txt
@@ -32,7 +32,7 @@ jupyterhub==1.3.0
 jupyter-rsession-proxy==1.2
 jupyter-tree-download==1.0.1
 ipywidgets==7.5.1
-otter-grader==2.2.5
+otter-grader==2.2.6
 datascience
 geojson
 folium


### PR DESCRIPTION
After the rpy2 dependency [otter-grader issue](https://github.com/ucbds-infra/otter-grader/issues/293) was resolved, I update the version here to 2.2.6 as well as bumped the image tag.

