### PR TITLE
Use spot instances for dask workers

### DIFF
--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -7,16 +7,24 @@ local clusterRegion = "us-west-2";
 local masterAzs = ["us-west-2a", "us-west-2b", "us-west-2c"];
 local nodeAz = "us-west-2a";
 
-// Node definitions for use with dask and notebook nodes
-// These are merged in with the defaults for either node type,
-// and so can contain any overrides.
-local nodes = [
+// Node definitions for notebook nodes. Only `instanceType` is
+// supported as a property.
+local notebookNodes = [
     { instanceType: "r5.large" },
     { instanceType: "r5.xlarge" },
     { instanceType: "r5.2xlarge" },
     { instanceType: "r5.8xlarge" },
     { instanceType: "x1.16xlarge" },
     { instanceType: "x1.32xlarge" }
+];
+
+// Node definitions for notebook nodes. Only `instanceType` is
+// supported as a property.
+local daskNodes = [
+    { instanceType: "r5.large" },
+    { instanceType: "r5.xlarge" },
+    { instanceType: "r5.2xlarge" },
+    { instanceType: "r5.8xlarge" },
 ];
 
 cluster {
@@ -44,10 +52,11 @@ cluster {
         ng {
             // NodeGroup names can't have a '.' in them, while
             // instanceTypes always have a .
-            name: "nb-%s" % std.strReplace(self.instanceType, ".", "-"),
+            name: "nb-%s" % std.strReplace(n.instanceType, ".", "-"),
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
+            instanceType: n.instanceType,
             ssh: {
                 publicKeyPath: 'ssh-keys/carbonplan.key.pub'
             },
@@ -60,12 +69,12 @@ cluster {
                 "hub.jupyter.org/dedicated": "user:NoSchedule"
             },
 
-        } + n for n in nodes
+        } + n for n in notebookNodes
     ] + [
         ng {
             // NodeGroup names can't have a '.' in them, while
             // instanceTypes always have a .
-            name: "dask-%s" % std.strReplace(self.instanceType, ".", "-"),
+            name: "dask-%s" % std.strReplace(n.instanceType, ".", "-"),
             availabilityZones: [nodeAz],
             minSize: 0,
             maxSize: 500,
@@ -79,8 +88,13 @@ cluster {
                 "k8s.dask.org_dedicated" : "worker:NoSchedule",
                 "k8s.dask.org/dedicated" : "worker:NoSchedule"
             },
-
-        } + n for n in nodes
+            instancesDistribution: {
+                instanceTypes: [n.instanceType],
+                onDemandBaseCapacity: 0,
+                onDemandPercentageAboveBaseCapacity: 0,
+                spotAllocationStrategy: "capacity-optimized",
+            },
+        } for n in daskNodes
     ]
 
 

--- a/eksctl/carbonplan.jsonnet
+++ b/eksctl/carbonplan.jsonnet
@@ -18,7 +18,7 @@ local notebookNodes = [
     { instanceType: "x1.32xlarge" }
 ];
 
-// Node definitions for notebook nodes. Only `instanceType` is
+// Node definitions for dask worker nodes. Only `instanceType` is
 // supported as a property.
 local daskNodes = [
     { instanceType: "r5.large" },

--- a/eksctl/libsonnet/nodegroup.jsonnet
+++ b/eksctl/libsonnet/nodegroup.jsonnet
@@ -18,7 +18,7 @@ local makeCloudTaints(taints) = {
   volumeSize: 80,
   labels+: {
 	  // Add instance type as label to nodegroups, so they
-	  // can be picked up by the autoscaler. If using spot instances,
+    // can be picked up by the autoscaler. If using spot instances,
     // pick the first instancetype
     'node.kubernetes.io/instance-type': if std.objectHas($, 'instanceType') then $.instanceType else $.instancesDistribution.instanceTypes[0],
   },

--- a/eksctl/libsonnet/nodegroup.jsonnet
+++ b/eksctl/libsonnet/nodegroup.jsonnet
@@ -15,12 +15,12 @@ local makeCloudTaints(taints) = {
   availabilityZones: [],
   minSize: 0,
   desiredCapacity: self.minSize,
-  instanceType: '',
   volumeSize: 80,
   labels+: {
 	  // Add instance type as label to nodegroups, so they
-	  // can be picked up by the autoscaler
-    'node.kubernetes.io/instance-type': $.instanceType,
+	  // can be picked up by the autoscaler. If using spot instances,
+    // pick the first instancetype
+    'node.kubernetes.io/instance-type': if std.objectHas($, 'instanceType') then $.instanceType else $.instancesDistribution.instanceTypes[0],
   },
   taints+: {},
   tags: makeCloudLabels(self.labels) + makeCloudTaints(self.taints),


### PR DESCRIPTION
- Don't change the instance type of the dask workers - so no
  mixed instances. This is a straight port of what we have now
  to just use spot instances.
- x1 spot instances can't be created due to quota issues,
  so we remove them from the pool.

Fixes https://github.com/2i2c-org/pilot-hubs/issues/490