### PR TITLE
Update catalystcoop hub image

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -327,7 +327,7 @@ hubs:
           singleuser:
             image:
               name: catalystcoop/pudl-jupyter
-              tag: 2021.03.27
+              tag: 2021.08.17
             memory:
               limit: 6G
               guarantee: 4G


### PR DESCRIPTION
Updating our docker image to use our v0.4.0 software release.

Also omg we are finally working on the Sloan projects.