### PR TITLE
Auth AWS EKS cluster with encrypted AWS credentials

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -26,7 +26,7 @@ jobs:
           # add its name to the list
           - 2i2c
           - cloudbank
-          # - carbonplan  # We need to edit deployer to connect to aws before we can autodeploy carbonplan
+          - carbonplan
           - meom-ige
           - pangeo-181919
 

--- a/config/hubs/carbonplan.cluster.yaml
+++ b/config/hubs/carbonplan.cluster.yaml
@@ -1,7 +1,10 @@
 name: carbonplan
-provider: kubeconfig
-kubeconfig:
-  file: secrets/carbonplan.yaml
+provider: aws
+aws:
+  key: secrets/carbonplan.json
+  clusterType: eks
+  clusterName: carbonplanhub
+  region: us-west-2
 support:
   config:
     prometheus:

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -79,25 +79,25 @@ properties:
     type: object
     additionalProperties: false
     description: |
-      Configuration to connect to the cluster on AWS. Is used when
-      provider is set to `aws`
+      Configuration to connect to the cluster on AWS.
+      Is used when provider is set to `aws`.
     properties:
       key:
         type: string
         description: |
-          Path to a `sops` encrypted JSON key that contains AWS credentials
-          with enough rights to get full access to the kubernetes cluster.
+          Path to a `sops` encrypted JSON file that contains the AWS credentials for the
+          "deployer" user (with enough rights to get full access to the cluster).
       clusterType:
         type: string
         description: |
-          We currently support kops and eks based kubernetes cluster on AWS.
+          We currently support `kops` and EKS-based cluster on AWS.
         enum:
           - kops
           - eks
       clusterName:
         type: string
         description: |
-          Name of the kubernetes cluster.
+          Name of the cluster.
       region:
         type: string
         description: |

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -30,6 +30,7 @@ properties:
     enum:
       - gcp
       - kubeconfig
+      - aws
   kubeconfig:
     type: object
     description: |
@@ -74,6 +75,35 @@ properties:
       - project
       - cluster
       - zone
+  aws:
+    type: object
+    additionalProperties: false
+    description: |
+      Configuration to connect to the cluster on AWS. Is used when
+      provider is set to `aws`
+    properties:
+      key:
+        type: string
+        description: |
+          Path to a `sops` encrypted JSON key that contains AWS credentials
+          with enough rights to get full access to the kubernetes cluster.
+      clusterType:
+        type: string
+        description: |
+          We currently support kops and eks based kubernetes cluster on AWS.
+      clusterName:
+        type: string
+        description: |
+          Name of the kubernetes cluster.
+      region:
+        type: string
+        description: |
+          The AWS region the cluster is in.
+    required:
+      - key
+      - clusterType
+      - clusterName
+      - region
   hubs:
     type: array
     description: |

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -91,6 +91,9 @@ properties:
         type: string
         description: |
           We currently support kops and eks based kubernetes cluster on AWS.
+        enum:
+          - kops
+          - eks
       clusterName:
         type: string
         description: |

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -164,8 +164,8 @@ class Cluster:
                     with open(decrypted_key_abspath) as f:
                         creds = json.load(f)
 
-                    os.environ['AWS_ACCESS_KEY_ID'] = creds['AccessKeyId']
-                    os.environ['AWS_SECRET_ACCESS_KEY'] = creds['SecretAccessKey']
+                    os.environ['AWS_ACCESS_KEY_ID'] = creds["AccessKey"]['AccessKeyId']
+                    os.environ['AWS_SECRET_ACCESS_KEY'] = creds["AccessKey"]['SecretAccessKey']
 
                 subprocess.check_call([
                     'aws', 'eks', 'update-kubeconfig',

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -40,6 +40,8 @@ class Cluster:
     def auth(self):
         if self.spec['provider'] == 'gcp':
             yield from self.auth_gcp()
+        elif self.spec['provider'] == 'aws':
+            yield from self.auth_aws()
         elif self.spec['provider'] == 'kubeconfig':
             yield from self.auth_kubeconfig()
         else:
@@ -139,6 +141,46 @@ class Cluster:
             # FIXME: Unset this after our yield
             os.environ['KUBECONFIG'] = decrypted_key_path
             yield
+
+    def auth_aws(self):
+        config = self.spec['aws']
+        key_path = config['key']
+        cluster_type = config['clusterType']
+        cluster_name = config['clusterName']
+        region = config['region']
+
+        with tempfile.NamedTemporaryFile() as kubeconfig:
+            orig_kubeconfig = os.environ.get('KUBECONFIG', None)
+            orig_access_key_id = os.environ.get('AWS_ACCESS_KEY_ID', None)
+            orig_secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY', None)
+            try:
+                os.environ['KUBECONFIG'] = kubeconfig.name
+                with decrypt_file(key_path) as decrypted_key_path:
+
+                    decrypted_key_abspath = os.path.abspath(decrypted_key_path)
+                    if not os.path.isfile(decrypted_key_abspath):
+                        raise FileNotFoundError(
+                            'The decrypted key file does not exist')
+                    with open(decrypted_key_abspath) as f:
+                        creds = json.load(f)
+
+                    os.environ['AWS_ACCESS_KEY_ID'] = creds['AccessKeyId']
+                    os.environ['AWS_SECRET_ACCESS_KEY'] = creds['SecretAccessKey']
+
+                subprocess.check_call([
+                    'aws', 'eks', 'update-kubeconfig',
+                    f'--name={cluster_name}',
+                    f'--region={region}'
+                ])
+
+                yield
+            finally:
+                if orig_kubeconfig is not None:
+                    os.environ['KUBECONFIG'] = orig_kubeconfig
+                if orig_access_key_id is not None:
+                    os.environ['AWS_ACCESS_KEY_ID'] = orig_access_key_id
+                if orig_kubeconfig is not None:
+                    os.environ['AWS_SECRET_ACCESS_KEY'] = orig_secret_access_key
 
     def auth_gcp(self):
         config = self.spec['gcp']

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -143,6 +143,10 @@ class Cluster:
             yield
 
     def auth_aws(self):
+        """
+        Reads `aws` nested config and temporarily sets environment variables
+        like `KUBECONFIG`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+        """
         config = self.spec['aws']
         key_path = config['key']
         cluster_type = config['clusterType']

--- a/secrets/carbonplan.json
+++ b/secrets/carbonplan.json
@@ -1,0 +1,27 @@
+{
+	"AccessKey": {
+		"UserName": "ENC[AES256_GCM,data:iy4RsyuXs7o=,iv:q6CdG9LhZrBt7Krrkum/MWQCPZio0dU5PeRQ+EXek+E=,tag:4HqueZU0Pp5TQmSMC/Hgcw==,type:str]",
+		"AccessKeyId": "ENC[AES256_GCM,data:1nyDLViEhulT6v1DPEtsFguY8gE=,iv:2Ng2gB86agOEQJTb7fC2Dodu/EypCV9SczizTd/K7go=,tag:/hbUbVAJhOIFyyG+IKwrhw==,type:str]",
+		"Status": "ENC[AES256_GCM,data:8K06P9kM,iv:Pxsc45npkwfPWOiurC+tPXD7rnYTG5dTi2xCkrd0mSE=,tag:qLLbpaLcB2Q+9M0zgovq/A==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:pY8Bi7iHeou+yE4HkES7gxAltF3y6fOgYEFNKYn+5ZytJ+5g9+97QA==,iv:QzmsgxtQWi6dJ0Qf4QIltEtgYKK1m0M3jibIlwchTok=,tag:EsgbO3Ycdpky2BTrXGE/mw==,type:str]",
+		"CreateDate": "ENC[AES256_GCM,data:zKReEKnqKewtrIndM2o79Btp580=,iv:lifyxCp9owSlknokgWXc8pR/rHJ0K3qui8LWD0Q1D20=,tag:eyiG++QNtEqB37311sAddQ==,type:str]"
+	},
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2021-09-01T13:03:36Z",
+				"enc": "CiQA4OM7eMFyAlMwyEXx2Hjb//VG4RSO9J0KxBh8UfKcNLgKXDgSSQC9ZQbLzAod3CJgYAxNlms7PKT9miAjdN85ALQDyDWcNewwc2LBaOHc0IEzGS1oLgjtnfE2vWYU7H9BTHMHnOLZrGpTCp/nvGM="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2021-09-01T13:03:37Z",
+		"mac": "ENC[AES256_GCM,data:z11MofsJ8drOQ7ZNB/NMA6flYRH+bkodeuj1Dm5v8obczfJ15sg7XqWuagZtqkt6lM8FTZ513bV1z/4Rbb7AJDICDyiQ0JkyRWj2dFY7D6Ygx9l2+jvl/9IunhjsAh0/GX/LZcWycTOIDRyhz0aLT+KEeRyU1GFeA8ms/JE92P4=,iv:vMFfym83wq3UvXBiv7XMVXRB4N0wSInlSReNzuItl8U=,tag:RuwpuXxNZE0ml04x874N/w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.1"
+	}
+}


### PR DESCRIPTION
~~This is a draft PR for early feedback.~~

I have added a new auth_aws function following the existing pattern for
the general auth context manager. The main idea was to get a temporary
kubeconfig file with the update-kubeconfig AWS CLI command [1] so we can
successfully connect with the EKS cluster. The command looks for the IAM
entity in your default AWS CLI to properly authenticate. In this case,
we are going to provide some 2i2c-deployer AWS credentials in a sops
encrypted json file and set up the Access Key ID and Secret Access Key
as environment variables.

I have also added some new values to the schema with the aim to replace
the current auth_kubeconfig with a future (more general) auth_aws
function working for kops-based clusters as well.

~~Btw, I have not provided the encrypted credentials file because currently contains my AWS credentials and I would like to test it with credentials associated with a 2i2c-deployer user I still need to create and give access to the cluster. More stuff in the next few days.~~

This is actually one step forward in #632 and half of #381 (which is intended for kops-based clusters instead of EKS ones).
