### PR TITLE
Update incident report to use new label name

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_incident-report.md
+++ b/.github/ISSUE_TEMPLATE/3_incident-report.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F4DD Incident report"
-about: Discuss what happened + next steps after an event.
+about: Report an incident on our running hub infrastructure.
 title: Incident Report - {{ TITLE }}
-labels: "type: post-mortem"
+labels: "type: incident report"
 assignees: ''
 
 ---


### PR DESCRIPTION
In our latest incident report (#637) I noted that our issue label is purely from a retrospective perspective, but I think it'd be more useful if we could open up an issue like that *during* the incident and update it periodically. This PR updates the label accordingly.

I'll merge this in an hour or two unless others protest since I think it's a pretty small/non-controversial chnge