### PR TITLE
Remove ohw specific node pools

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -102,15 +102,6 @@ hubs:
     auth0:
       connection: github
     config:
-      dask-gateway:
-        gateway:
-          backend:
-            scheduler:
-              nodeSelector:
-                2i2c.org/community: ohw
-            worker:
-              nodeSelector:
-                2i2c.org/community: ohw
       basehub:
         jupyterhub:
           prePuller:
@@ -142,8 +133,6 @@ hubs:
             image:
               name: ghcr.io/oceanhackweek/jupyer-image
               tag: 9efd4fb
-            nodeSelector:
-                2i2c.org/community: ohw
             memory:
               # Increase memory alloted during the workshop
               #  https://github.com/2i2c-org/pilot-hubs/issues/549#issuecomment-891264570

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -15,14 +15,6 @@ notebook_nodes = {
     max : 20,
     machine_type : "e2-highmem-4",
     labels: { }
-  },
-  "ohw": {
-    min: 0,
-    max: 50,
-    machine_type: "n1-highmem-4",
-    labels: {
-      "2i2c.org/community": "ohw"
-    },
   }
 }
 
@@ -32,14 +24,6 @@ dask_nodes = {
     max : 100,
     machine_type : "e2-highmem-4",
     labels: { }
-  },
-  "ohw": {
-    min: 0,
-    max: 100,
-    machine_type: "n1-highmem-4",
-    labels: {
-      "2i2c.org/community": "ohw"
-    },
   }
 }
 


### PR DESCRIPTION
We gave them their own node pool for better guarantees
of user and dask worker spinup time. The hackathon has
been over for a while, so we can turn this down.

Ref https://github.com/2i2c-org/pilot-hubs/issues/595

`terraform plan` output:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  - destroy

Terraform will perform the following actions:

  # google_container_node_pool.dask_worker["ohw"] will be destroyed
  - resource "google_container_node_pool" "dask_worker" {
      - cluster             = "pilot-hubs-cluster" -> null
      - id                  = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/dask-ohw" -> null
      - initial_node_count  = 50 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/two-eye-two-see/zones/us-central1-b/instanceGroupManagers/gke-pilot-hubs-cluster-dask-ohw-e2d5227a-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - name                = "dask-ohw" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "two-eye-two-see" -> null
      - version             = "1.19.9-gke.1900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-ssd" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "2i2c.org/community"        = "ohw"
              - "k8s.dask.org/node-purpose" = "worker"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-highmem-4" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = true -> null
          - service_account   = "pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "k8s.dask.org_dedicated"
                  - value  = "worker"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.notebook["ohw"] will be destroyed
  - resource "google_container_node_pool" "notebook" {
      - cluster             = "pilot-hubs-cluster" -> null
      - id                  = "projects/two-eye-two-see/locations/us-central1-b/clusters/pilot-hubs-cluster/nodePools/nb-ohw" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/two-eye-two-see/zones/us-central1-b/instanceGroupManagers/gke-pilot-hubs-cluster-nb-ohw-f0522561-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - name                = "nb-ohw" -> null
      - node_count          = 2 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "two-eye-two-see" -> null
      - version             = "1.19.9-gke.1900" -> null

      - autoscaling {
          - max_node_count = 50 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-standard" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "2i2c.org/community"           = "ohw"
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-highmem-4" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - service_account   = "pilot-hubs-cluster-sa@two-eye-two-see.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

Plan: 0 to add, 0 to change, 2 to destroy.
```