### PR TITLE
Use n1- instances instead of e2 instances

### DIFF
--- a/config/hubs/meom-ige.cluster.yaml
+++ b/config/hubs/meom-ige.cluster.yaml
@@ -56,35 +56,35 @@ hubs:
                   mem_limit: 8G
                   mem_guarantee: 5.5G
                   node_selector:
-                    node.kubernetes.io/instance-type: e2-standard-2
+                    node.kubernetes.io/instance-type: n1-standard-2
               - display_name: "Medium"
                 description: "~8 CPU, ~32G RAM"
                 kubespawner_override:
                   mem_limit: 32G
                   mem_guarantee: 25G
                   node_selector:
-                    node.kubernetes.io/instance-type: e2-standard-8
+                    node.kubernetes.io/instance-type: n1-standard-8
               - display_name: "Large"
                 description: "~16 CPU, ~64G RAM"
                 kubespawner_override:
                   mem_limit: 64G
                   mem_guarantee: 55G
                   node_selector:
-                    node.kubernetes.io/instance-type: e2-standard-16
+                    node.kubernetes.io/instance-type: n1-standard-16
               - display_name: "Very Large"
                 description: "~32 CPU, ~128G RAM"
                 kubespawner_override:
                   mem_limit: 128G
                   mem_guarantee: 115G
                   node_selector:
-                    node.kubernetes.io/instance-type: e2-standard-32
+                    node.kubernetes.io/instance-type: n1-standard-32
               - display_name: "Huge"
                 description: "~64 CPU, ~256G RAM"
                 kubespawner_override:
                   mem_limit: 256G
                   mem_guarantee: 230G
                   node_selector:
-                    node.kubernetes.io/instance-type: n2-standard-64
+                    node.kubernetes.io/instance-type: n1-standard-64
             defaultUrl: /lab
             image:
               name: pangeo/pangeo-notebook

--- a/config/hubs/meom-ige.cluster.yaml
+++ b/config/hubs/meom-ige.cluster.yaml
@@ -54,7 +54,7 @@ hubs:
                 description: "~2 CPU, ~8G RAM"
                 kubespawner_override:
                   mem_limit: 8G
-                  mem_guarantee: 5.5G
+                  mem_guarantee: 5G
                   node_selector:
                     node.kubernetes.io/instance-type: n1-standard-2
               - display_name: "Medium"
@@ -68,21 +68,21 @@ hubs:
                 description: "~16 CPU, ~64G RAM"
                 kubespawner_override:
                   mem_limit: 64G
-                  mem_guarantee: 55G
+                  mem_guarantee: 50G
                   node_selector:
                     node.kubernetes.io/instance-type: n1-standard-16
               - display_name: "Very Large"
                 description: "~32 CPU, ~128G RAM"
                 kubespawner_override:
                   mem_limit: 128G
-                  mem_guarantee: 115G
+                  mem_guarantee: 110G
                   node_selector:
                     node.kubernetes.io/instance-type: n1-standard-32
               - display_name: "Huge"
                 description: "~64 CPU, ~256G RAM"
                 kubespawner_override:
                   mem_limit: 256G
-                  mem_guarantee: 230G
+                  mem_guarantee: 220G
                   node_selector:
                     node.kubernetes.io/instance-type: n1-standard-64
             defaultUrl: /lab

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -8,6 +8,16 @@ resource "google_container_cluster" "cluster" {
 
   initial_node_count       = 1
   remove_default_node_pool = true
+  lifecycle {
+    # Any change to the default node_config forces cluster recreation,
+    # and sometimes terraform seems to mess up and think we have changed
+    # something here when we have not. So we explicitly ignore all changes
+    # to node_config - we remove any nodepool it might create with
+    # remove_default_node_pool = true.
+    ignore_changes = [
+      node_config
+    ]
+  }
 
   // For private clusters, pass the name of the network and subnetwork created
   // by the VPC

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -14,7 +14,7 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "e2-highmem-4"
+    machine_type : "n1-highmem-4"
   },
 }
 
@@ -22,7 +22,7 @@ dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-4"
+    machine_type : "n1-highmem-4"
   },
 }
 

--- a/terraform/gcp/projects/cloudbank.tfvars
+++ b/terraform/gcp/projects/cloudbank.tfvars
@@ -14,7 +14,8 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "n1-highmem-4"
+    machine_type : "n1-highmem-4",
+    labels: {}
   },
 }
 
@@ -22,7 +23,8 @@ dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-4"
+    machine_type : "n1-highmem-4",
+    labels: {}
   },
 }
 

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -23,28 +23,27 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 20,
-    machine_type : "e2-standard-2"
+    machine_type : "n1-standard-2"
   },
   "medium" : {
     min : 0,
     max : 20,
-    machine_type : "e2-standard-8"
+    machine_type : "n1-standard-8"
   },
   "large" : {
     min : 0,
     max : 20,
-    machine_type : "e2-standard-16"
+    machine_type : "n1-standard-16"
   },
   "very-large" : {
     min : 0,
     max : 20,
-    machine_type : "e2-standard-32"
+    machine_type : "n1-standard-32"
   },
   "huge" : {
     min : 0,
     max : 20,
-    # e2 instances only go upto 32 cores
-    machine_type : "n2-standard-64"
+    machine_type : "n1-standard-64"
   },
 
 }

--- a/terraform/gcp/projects/meom-ige.tfvars
+++ b/terraform/gcp/projects/meom-ige.tfvars
@@ -23,27 +23,32 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-2"
+    machine_type : "n1-standard-2",
+    labels: {}
   },
   "medium" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-8"
+    machine_type : "n1-standard-8",
+    labels: {}
   },
   "large" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-16"
+    machine_type : "n1-standard-16",
+    labels: {}
   },
   "very-large" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-32"
+    machine_type : "n1-standard-32",
+    labels: {}
   },
   "huge" : {
     min : 0,
     max : 20,
-    machine_type : "n1-standard-64"
+    machine_type : "n1-standard-64",
+    labels: {}
   },
 
 }

--- a/terraform/gcp/projects/pilot-hubs.tfvars
+++ b/terraform/gcp/projects/pilot-hubs.tfvars
@@ -13,7 +13,7 @@ notebook_nodes = {
   "user" : {
     min : 0,
     max : 20,
-    machine_type : "e2-highmem-4",
+    machine_type : "n1-highmem-4",
     labels: { }
   }
 }
@@ -22,7 +22,7 @@ dask_nodes = {
   "worker" : {
     min : 0,
     max : 100,
-    machine_type : "e2-highmem-4",
+    machine_type : "n1-highmem-4",
     labels: { }
   }
 }


### PR DESCRIPTION
n1 instances get a sustained use discount while e2 instances
do not. I had previously believed that n1 instances did *not*
get this discount if they were not running all the time. However,
this is not true, based on a re-reading of
https://cloud.google.com/compute/docs/sustained-use-discounts.

Switching to n1 instances will give us pretty good cost savings.

# Tasks

Deploy this change to:

- [x] CloudBank
- [x] Pilot Hubs
- [ ] MEOM-IGE

closes https://github.com/2i2c-org/pilot-hubs/issues/715