### PR TITLE
Prototype single list of admin users

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -16,6 +16,23 @@ support:
           - secretName: grafana-tls
             hosts:
               - grafana.pilot.2i2c.cloud
+staff:
+  # Alphabetical for github handles, and OAuth usernames follow same order as github
+  names:
+    github: &staff-github
+      - choldgraf
+      - consideRatio
+      - damianavila
+      - GeorgianaElena
+      - sgibson91
+      - yuvipanda
+    google_oauth: &staff-google-oauth
+    - choldgraf@2i2c.org
+    - erik@2i2c.org
+    - damianavila@2i2c.org
+    - georgiana.dolocan@gmail.com
+    - sgibson@2i2c.org
+    - yuvipanda@2i2c.org
 hubs:
   - name: staging
     domain: staging.pilot.2i2c.cloud
@@ -48,10 +65,8 @@ hubs:
           config:
             Authenticator:
               allowed_users: &staging_users
-                - yuvipanda@gmail.com
-                - colliand@gmail.com
-                - choldgraf@gmail.com
-                - georgiana.dolocan@gmail.com
+                - *staff-google-oauth
+                - anextrausername
               admin_users: *staging_users
   - name: dask-staging
     domain: dask-staging.pilot.2i2c.cloud

--- a/deployer/__main__.py
+++ b/deployer/__main__.py
@@ -11,7 +11,7 @@ from ruamel.yaml import YAML
 
 from auth import KeyProvider
 from hub import Cluster
-from utils import decrypt_file
+from utils import decrypt_file, clean_config
 
 # Without `pure=True`, I get an exception about str / byte issues
 yaml = YAML(typ="safe", pure=True)
@@ -90,9 +90,11 @@ def deploy(cluster_name, hub_name, skip_hub_health_test, config_path):
         hubs = cluster.hubs
         if hub_name:
             hub = next((hub for hub in hubs if hub.spec["name"] == hub_name), None)
+            clean_config(hub["config"])
             hub.deploy(k, SECRET_KEY, skip_hub_health_test)
         else:
             for hub in hubs:
+                clean_config(hub["config"])
                 hub.deploy(k, SECRET_KEY, skip_hub_health_test)
 
 

--- a/deployer/utils.py
+++ b/deployer/utils.py
@@ -47,3 +47,33 @@ def decrypt_file(encrypted_path):
             '--decrypt', encrypted_path
         ])
         yield f.name
+
+
+def flatten(inputlist):
+    """
+    Flatten a list of strings and lists into a flat list of strings.
+    This will only work 1-level deep.
+
+    Parameters
+    ==========
+    names: list of strings and/or lists
+        The 
+    """
+    if isinstance(inputlist, str):
+        inputlist = [inputlist]
+    out = []
+    for ii in inputlist:
+        if isinstance(ii, str):
+            out.append(ii)
+        else:
+            out.extend(ii)
+    return out
+
+
+def clean_config(config):
+    """Prepare a hub's configuration file for deployment."""
+
+    # Flatten authenticated user list since YAML references don't extend, they append
+    authenticator = config.get("jupyterhub", {}).get("hub", {}).get("config", {}).get("Authenticator", {})
+    authenticator["allowed_users"] = flatten(authenticator["allowed_users"])
+    authenticator["admin_users"] = flatten(authenticator["admin_users"])


### PR DESCRIPTION
In creating the AUP hub, I ran into the issue of needing to choose admin users from the other lists on the page. I wanted to see if we could define a quick way to streamline this process so that know that all 2i2c Engineers have access to all hubs.

I am curious what people think about the current PR. It uses YAML references to define admin users once and insert them throughout the hubs.

There is one problem with this: when you insert YAML lists like this, they aren't flattened, so something like:

```yaml
keyone: &mykey
  - a
  - b
keytwo:
- *mykey
- c
```

effectively becomes

```yaml
```yaml
keyone: &mykey
  - a
  - b
keytwo:
- - a
  - b
- c
```

To get around this, I added a little utility function that just searches through the `Authenticator` config and flattens its contents. See diff for details!

# My question

Is this a feasible stop-gap solution to only require maintaining a single list of users? Is there any way for us to process that list with a `flatten` function before passing it to JupyterHub?

# Tasks

- [ ] Decide if this is a reasonable approach
- [ ] If so, add docs to describe how this affects new hub creation
- [ ] Update our pre-existing hubs to follow this pattern