### PR TITLE
Add AUP hub

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -436,3 +436,43 @@ hubs:
                 - fzhu2e
                 - alexkjames
               admin_users: *paleohack_users
+  - name: aup
+    domain: aup.pilot.2i2c.cloud
+    template: basehub
+    auth0:
+      connection: github
+    config:
+      jupyterhub:
+        custom:
+          homepage:
+            templateVars:
+              org:
+                name: The American University of Paris
+                logo_url: https://www.aup.edu/sites/all/themes/aup_2018/img/home/logo_homepage.png
+                url: https://www.aup.edu/
+              designed_by:
+                name: 2i2c
+                url: https://2i2c.org
+              operated_by:
+                name: 2i2c
+                url: https://2i2c.org
+              funded_by:
+                name: AUP
+                url: https://www.aup.edu/
+        singleuser:
+          memory:
+            limit: 2G
+            guarantee: 2G
+        hub:
+          config:
+            Authenticator:
+              allowed_users: &aup_users
+              - choldgraf
+              - consideRatio
+              - damianavila
+              - GeorgianaElena
+              - sgibson91
+              - yuvipanda
+              - swalker
+              - shaolintl
+              admin_users: *aup_users


### PR DESCRIPTION
This adds a hub for the American University of Paris. It starts off with a small environment (2G RAM per user) but hopefully this is enough for most light educational cases. @shaolintl and @swalker can bump up the memory via the configurator if need be (https://pilot.2i2c.org/en/latest/admin/howto/configurator.html).

I'd love if somebody from the @2i2c-org/tech-team could take a look and approve to make sure I got the config right.

Note also that I opened up #667 as a quick idea while I was implementing this. Would love thoughts there :-)

closes https://github.com/2i2c-org/pilot-hubs/issues/659