### PR TITLE
Allow for node auto-provisioning and enable this for Pangeo cluster

### DIFF
--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -96,16 +96,6 @@ resource "google_container_cluster" "cluster" {
         maximum       = var.max_cpu
       }
     }
-
-    // When node auto-provisioning is enabled, define the service account to be
-    // used by the node VMs
-    dynamic "auto_provisioning_defaults" {
-      for_each = var.enable_node_autoprovisioning ? [1] : []
-
-      content {
-        service_account = google_service_account.cluster_sa.email
-      }
-    }
   }
 
   network_policy {

--- a/terraform/gcp/cluster.tf
+++ b/terraform/gcp/cluster.tf
@@ -108,13 +108,6 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  // When node auto-provisioning is enabled, also enable vertical pod autoscaling
-  // Following Pangeo setup documented here:
-  // https://github.com/pangeo-data/pangeo-cloud-federation/blob/d051d1829aeb303d321dd483450146891f67a93c/deployments/gcp-uscentral1b/Makefile#L47
-  vertical_pod_autoscaling {
-    enabled = var.enable_node_autoprovisioning
-  }
-
   network_policy {
     enabled = var.enable_network_policy
   }

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -1,45 +1,20 @@
 prefix                 = "pangeo-hubs"
 project_id             = "pangeo-integration-te-3eea"
+core_node_machine_type = "n1-highmem-4"
 enable_private_cluster = true
 
-core_node_machine_type = "n1-highmem-4"
-
 # Multi-tenant cluster, network policy is required to enforce separation between hubs
-enable_network_policy    = true
+enable_network_policy  = true
 
 # Some hubs want a storage bucket, so we need to have config connector enabled
 config_connector_enabled = true
 
+# Setup a filestore for in-cluster NFS
+enable_filestore = true
 
-notebook_nodes = {
-  "small" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-2",
-    labels: {}
-  },
-  "medium" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-8",
-    labels: {}
-  },
-  "large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-16",
-    labels: {}
-  },
-  "very-large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-standard-32",
-    labels: {}
-  },
-}
+# Enable node auto-provisioning
+enable_node_autoprovisioning = true
 
 user_buckets = [
   "pangeo-scratch"
 ]
-
-enable_filestore = true

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -220,3 +220,57 @@ variable "filestore_tier" {
   BASIC_SSD (for faster home directories, min $768 / month)
   EOT
 }
+
+variable "enable_node_autoprovisioning" {
+  type = bool
+  default = false
+  description = <<-EOT
+  Enable auto-provisioning of nodes based on workload
+  EOT
+}
+
+// Defaults for the below variables are taken from the original Pangeo cluster setup
+// https://github.com/pangeo-data/pangeo-cloud-federation/blob/d051d1829aeb303d321dd483450146891f67a93c/deployments/gcp-uscentral1b/Makefile#L25
+variable "min_memory" {
+  type        = number
+  default     = 1
+  description = <<-EOT
+  When auto-provisioning nodes, this is the minimum amount of memory the nodes
+  should allocate in GB.
+
+  Default = 1 GB
+  EOT
+}
+
+variable "max_memory" {
+  type        = number
+  default     = 5200
+  description = <<-EOT
+  When auto-provisioning nodes, this is the minimum amount of memory the nodes
+  should allocate in GB.
+
+  Default = 5200 GB
+  EOT
+}
+
+variable "min_cpu" {
+  type        = number
+  default     = 1
+  description = <<-EOT
+  When auto-provisioning nodes, this is the minimum number of cores in the
+  cluster to which the cluster can scale.
+
+  Default = 1 CPU
+  EOT
+}
+
+variable "max_cpu" {
+  type        = number
+  default     = 1000
+  description = <<-EOT
+  When auto-provisioning nodes, this is the minimum number of cores in the
+  cluster to which the cluster can scale.
+
+  Default = 1000
+  EOT
+}


### PR DESCRIPTION
### Summary

This PR updates the terraform config to allow us to enable [node auto-provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning) on GKE clusters if required (defaults to not enabled).

This change came out of discussion in #666 and I've tried to replicate the setup of the original Pangeo cluster as best I can as it's documented here: https://github.com/pangeo-data/pangeo-cloud-federation/blob/staging/deployments/gcp-uscentral1b/Makefile Note that this may not be the configuration we want to keep for the long-term, but I think it should suffice for Pangeo's immediate needs.

The PR also enables this for Pangeo. Terraform plan output below. The destroyed changes are the pre-configured nodepools, but the actually cluster is being updated in place, so this isn't a super disruptive PR for live infrastructure.

```

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # google_container_cluster.cluster will be updated in-place
  ~ resource "google_container_cluster" "cluster" {
        id                          = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster"
        name                        = "pangeo-hubs-cluster"
        # (28 unchanged attributes hidden)


      ~ cluster_autoscaling {
          ~ enabled             = false -> true
            # (1 unchanged attribute hidden)

          + auto_provisioning_defaults {
              + oauth_scopes    = (known after apply)
              + service_account = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
            }

          + resource_limits {
              + maximum       = 5200
              + minimum       = 1
              + resource_type = "memory"
            }
          + resource_limits {
              + maximum       = 1000
              + minimum       = 1
              + resource_type = "cpu"
            }
        }













        # (22 unchanged blocks hidden)
    }

  # google_container_node_pool.dask_worker["large"] will be destroyed
  - resource "google_container_node_pool" "dask_worker" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/dask-large" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-dask-large-a75bd4ce-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "dask-large" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-ssd" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "k8s.dask.org/node-purpose" = "worker"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-16" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = true -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "k8s.dask.org_dedicated"
                  - value  = "worker"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.dask_worker["medium"] will be destroyed
  - resource "google_container_node_pool" "dask_worker" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/dask-medium" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-dask-medium-3e5bd798-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "dask-medium" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-ssd" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "k8s.dask.org/node-purpose" = "worker"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-8" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = true -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "k8s.dask.org_dedicated"
                  - value  = "worker"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.dask_worker["small"] will be destroyed
  - resource "google_container_node_pool" "dask_worker" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/dask-small" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-dask-small-0afd7298-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "dask-small" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-ssd" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "k8s.dask.org/node-purpose" = "worker"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-2" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = true -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "k8s.dask.org_dedicated"
                  - value  = "worker"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.dask_worker["very-large"] will be destroyed
  - resource "google_container_node_pool" "dask_worker" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/dask-very-large" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-clust-dask-very-large-351a72c9-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "dask-very-large" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-ssd" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "k8s.dask.org/node-purpose" = "worker"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-32" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = true -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "k8s.dask.org_dedicated"
                  - value  = "worker"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.notebook["large"] will be destroyed
  - resource "google_container_node_pool" "notebook" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/nb-large" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-nb-large-7ed196c7-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "nb-large" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-standard" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-16" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.notebook["medium"] will be destroyed
  - resource "google_container_node_pool" "notebook" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/nb-medium" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-nb-medium-1831e6d5-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "nb-medium" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-standard" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-8" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.notebook["small"] will be destroyed
  - resource "google_container_node_pool" "notebook" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/nb-small" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-nb-small-2e77259a-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "nb-small" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-standard" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-2" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

  # google_container_node_pool.notebook["very-large"] will be destroyed
  - resource "google_container_node_pool" "notebook" {
      - cluster             = "pangeo-hubs-cluster" -> null
      - id                  = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster/nodePools/nb-very-large" -> null
      - initial_node_count  = 0 -> null
      - instance_group_urls = [
          - "https://www.googleapis.com/compute/v1/projects/pangeo-integration-te-3eea/zones/us-central1-b/instanceGroupManagers/gke-pangeo-hubs-cluster-nb-very-large-2df6f2a3-grp",
        ] -> null
      - location            = "us-central1-b" -> null
      - max_pods_per_node   = 110 -> null
      - name                = "nb-very-large" -> null
      - node_count          = 0 -> null
      - node_locations      = [
          - "us-central1-b",
        ] -> null
      - project             = "pangeo-integration-te-3eea" -> null
      - version             = "1.20.8-gke.900" -> null

      - autoscaling {
          - max_node_count = 100 -> null
          - min_node_count = 0 -> null
        }

      - management {
          - auto_repair  = true -> null
          - auto_upgrade = false -> null
        }

      - node_config {
          - disk_size_gb      = 100 -> null
          - disk_type         = "pd-standard" -> null
          - guest_accelerator = [] -> null
          - image_type        = "COS_CONTAINERD" -> null
          - labels            = {
              - "hub.jupyter.org/node-purpose" = "user"
              - "k8s.dask.org/node-purpose"    = "scheduler"
            } -> null
          - local_ssd_count   = 0 -> null
          - machine_type      = "n1-standard-32" -> null
          - metadata          = {
              - "disable-legacy-endpoints" = "true"
            } -> null
          - oauth_scopes      = [
              - "https://www.googleapis.com/auth/cloud-platform",
            ] -> null
          - preemptible       = false -> null
          - service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com" -> null
          - tags              = [] -> null
          - taint             = [
              - {
                  - effect = "NO_SCHEDULE"
                  - key    = "hub.jupyter.org_dedicated"
                  - value  = "user"
                },
            ] -> null

          - shielded_instance_config {
              - enable_integrity_monitoring = true -> null
              - enable_secure_boot          = false -> null
            }

          - workload_metadata_config {
              - node_metadata = "GKE_METADATA_SERVER" -> null
            }
        }

      - upgrade_settings {
          - max_surge       = 1 -> null
          - max_unavailable = 0 -> null
        }
    }

Plan: 0 to add, 1 to change, 8 to destroy.
```