### PR TITLE
Use an AWS deployer user to fetch kubernetes credentials in our deployer

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -28,6 +28,7 @@ jobs:
           - cloudbank
           - carbonplan
           - farallon
+          # Uncomment openscapes once a deployer user is created in openscapes AWS land
           # - openscapes
           - meom-ige
           - pangeo-181919
@@ -88,9 +89,11 @@ jobs:
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true')
         run: |
-          curl -Lo kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
+          curl -Lo kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64
           chmod +x kops
           sudo mv kops /usr/local/bin/kops
+        env:
+          KOPS_VERSION: "v1.21.1"
 
       - name: Deploy ${{ matrix.cluster_name }}
         if: |

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -87,7 +87,10 @@ jobs:
         if: |
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true')
-        uses: hiberbee/github-action-kops@1.0.0
+        run: |
+          curl -Lo kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64
+          chmod +x kops
+          sudo mv kops /usr/local/bin/kops
 
       - name: Deploy ${{ matrix.cluster_name }}
         if: |

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -27,6 +27,8 @@ jobs:
           - 2i2c
           - cloudbank
           - carbonplan
+          - farallon
+          # - openscapes
           - meom-ige
           - pangeo-181919
           - pangeo-hubs
@@ -80,6 +82,12 @@ jobs:
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true')
         uses: mdgreenwald/mozilla-sops-action@v1
+
+      - name: Setup kops
+        if: |
+          (steps.base_files.outputs.files == 'true') ||
+          (steps.config_files.outputs.hub_config == 'true')
+        uses: hiberbee/github-action-kops@1.0.0
 
       - name: Deploy ${{ matrix.cluster_name }}
         if: |

--- a/config/hubs/farallon.cluster.yaml
+++ b/config/hubs/farallon.cluster.yaml
@@ -1,7 +1,11 @@
 name: farallon
-provider: kubeconfig
-kubeconfig:
-  file: secrets/farallon.yaml
+provider: aws
+aws:
+  key: secrets/farallon.json
+  clusterType: kops
+  clusterName: farallonhub.k8s.local
+  region: us-east-2
+  stateStore: s3://2i2c-farallon-kops-state
 hubs:
   - name: staging
     domain: staging.farallon.2i2c.cloud

--- a/config/hubs/schema.yaml
+++ b/config/hubs/schema.yaml
@@ -102,11 +102,23 @@ properties:
         type: string
         description: |
           The AWS region the cluster is in.
+      stateStore:
+        type: string
+        description: |
+          A dedicated S3 bucket for kops to use in order to store the state
+          (and the representation) of your of your kops cluster.
     required:
       - key
       - clusterType
       - clusterName
       - region
+    if:
+      properties:
+        clusterType:
+          const: kops
+    then:
+      required:
+        - stateStore
   hubs:
     type: array
     description: |

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -183,8 +183,8 @@ class Cluster:
                 if cluster_type == 'kops':
                     subprocess.check_call([
                         'kops', 'export', 'kubecfg', '--admin',
-                        f'--name {cluster_name}',
-                        f'--state {state_store}'
+                        f'--name={cluster_name}',
+                        f'--state={state_store}'
                     ])
                 else:
                     subprocess.check_call([

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -146,7 +146,8 @@ class Cluster:
         """
         Reads `aws` nested config and temporarily sets environment variables
         like `KUBECONFIG`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`
-        before trying to authenticate with the aws eks update-kubeconfig command.
+        before trying to authenticate with the `aws eks update-kubeconfig` or
+        the `kops export kubecfg --admin` commands.
 
         Finally get those environment variables to the original values to prevent
         side-effects on existing local configuration.
@@ -156,6 +157,9 @@ class Cluster:
         cluster_type = config['clusterType']
         cluster_name = config['clusterName']
         region = config['region']
+
+        if cluster_type == 'kops':
+            state_store = config['stateStore']
 
         with tempfile.NamedTemporaryFile() as kubeconfig:
             orig_kubeconfig = os.environ.get('KUBECONFIG', None)
@@ -176,11 +180,18 @@ class Cluster:
 
                 os.environ['KUBECONFIG'] = kubeconfig.name
 
-                subprocess.check_call([
-                    'aws', 'eks', 'update-kubeconfig',
-                    f'--name={cluster_name}',
-                    f'--region={region}'
-                ])
+                if cluster_type == 'kops':
+                    subprocess.check_call([
+                        'kops', 'export', 'kubecfg', '--admin',
+                        f'--name {cluster_name}',
+                        f'--state {state_store}'
+                    ])
+                else:
+                    subprocess.check_call([
+                        'aws', 'eks', 'update-kubeconfig',
+                        f'--name={cluster_name}',
+                        f'--region={region}'
+                    ])
 
                 yield
             finally:

--- a/secrets/farallon.json
+++ b/secrets/farallon.json
@@ -1,0 +1,27 @@
+{
+	"AccessKey": {
+		"UserName": "ENC[AES256_GCM,data:xzejx3ekJ3o=,iv:6pkDM1SlOUZam95khZZsRkszGpf8rzE87ZZFTYfPuNA=,tag:TYF7ctbZ3szuY88kA8MyCg==,type:str]",
+		"AccessKeyId": "ENC[AES256_GCM,data:baIaSl6LkHTPI6VlIDFU/vhLjHI=,iv:lS1kSvvyB0BCnJ2ROt5ZYqKwRHD5+8PGttyrJRrfNt4=,tag:aATT82STHnqA0gJ18Z6h1w==,type:str]",
+		"Status": "ENC[AES256_GCM,data:dITKVJJU,iv:zNPAZiM9WlBGFcqTtgYZMCIUYFLGJeIkgnolyL70paU=,tag:y5dsK27jgopRA4YTjFeBTw==,type:str]",
+		"SecretAccessKey": "ENC[AES256_GCM,data:dv1lLpX+oNckM99jq9XyNDtmvatshvw0vG1R7um3eSWAAK5mhR8lPQ==,iv:vQijh5x9aXKkvwGtC+tz4K7c/2cC+4RS7ZhuR1nH8aE=,tag:DUVVUWjMQVzQ1+COT3gZjQ==,type:str]",
+		"CreateDate": "ENC[AES256_GCM,data:lTRvSgoBvv78lZKaMyo7FFaM1TY=,iv:GCLCdzuNmKebeQ36vFw1j6hLxzBXbauytA+b9rjpXyE=,tag:QQu4b+NFPCbO3VmP8eTo4Q==,type:str]"
+	},
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2021-09-10T19:47:17Z",
+				"enc": "CiQA4OM7eADZ6//P01khGg4CZO59PqPjFbWve5/BrnloowSkutESSQC9ZQbLAKgNPACzbKGS+Na1TnvxQ5HfjKGuRpe28hjxPRxLdYtjrFAJS9sLzMpMUOS10chi3N6SWLLbngM0mDIpCpx5nAzCjiI="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2021-09-10T19:47:19Z",
+		"mac": "ENC[AES256_GCM,data:n/hHhm2IdIQOy/s0yyRr9XzRU0sVTLa4VbzqdSWJ91ZtUiGdbBB6sw81lxRFv7x2MXnlGrBVs6QS07urB31QB7ryr1BhRDJeA0tVzceGf6KGmpqih3luWqEEtrtIwQSuqKgNueEQ4zcNmLq7KavfQkijE3MGYnoAudU/FavChFY=,iv:TO/jhfTpM03n71o9Sx/krrCmtuB/qyQg9FFBTdks5ec=,tag:EVg4qv2iP9SFnj0j0q7sIA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.1"
+	}
+}


### PR DESCRIPTION
Summary:

The auth_aws function I recently added to the deployer is now authenticating kops-based clusters.
Farallon would be the first one.
You can see more details in the commit messages.
You may find interesting the usage of if and else keyword in the schema to properly validate the config file.

Btw, this one still needs to be more tested but I believe is complete so putting it out there to get early feedback.

Closes #381