### PR TITLE
Update Pangeo hub's profile list

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -75,6 +75,9 @@ hubs:
                   - rabernat
                 admin_users: *staging_users
           singleuser:
+            image:
+              name: pangeo/pangeo-notebook
+              tag: bcfacc5
             profileList:
               # The mem-guarantees are here so k8s doesn't schedule other pods
               # on these nodes. They need to be just under total allocatable
@@ -125,15 +128,6 @@ hubs:
               - name: home
                 mountPath: /home/jovyan
                 subPath: "{username}"
-            image:
-              name: pangeo/pangeo-notebook
-              tag: bcfacc5
-            cpu:
-              limit: 2
-              guarantee: 1
-            memory:
-              limit: 4G
-              guarantee: 2G
       dask-gateway:
         gateway:
           backend:

--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -89,24 +89,18 @@ hubs:
                   cpu_guarantee: 0.3
                   mem_limit: 4G
                   mem_guarantee: 1G
-                  node_selector:
-                    node.kubernetes.io/instance-type: n1-standard-16
               - display_name: "Medium (4 GB - 8 GB)"
                 kubespawner_override:
                   cpu_limit: 2
                   cpu_guarantee: 1
                   mem_limit: 8G
                   mem_guarantee: 4G
-                  node_selector:
-                    node.kubernetes.io/instance-type: n1-standard-32
               - display_name: "Large (12 GB - 16 GB)"
                 kubespawner_override:
                   cpu_limit: 4
                   cpu_guarantee: 1
                   mem_limit: 16G
                   mem_guarantee: 12G
-                  node_selector:
-                    node.kubernetes.io/instance-type: n1-highmem-16
               - display_name: "ML Image - Large (12 GB - 16 GB)"
                 description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
                 kubespawner_override:
@@ -115,8 +109,6 @@ hubs:
                   cpu_guarantee: 1
                   mem_limit: 16G
                   mem_guarantee: 12G
-                  node_selector:
-                    node.kubernetes.io/instance-type: n1-highmem-16
             initContainers:
               # Need to explicitly fix ownership here, since EFS doesn't do anonuid
             - name: volume-mount-ownership-fix

--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -90,7 +90,7 @@ hubs:
                   mem_limit: 4G
                   mem_guarantee: 1G
                   node_selector:
-                    node.kubernetes.io/size: small
+                    node.kubernetes.io/instance-type: n1-standard-16
               - display_name: "Medium (4 GB - 8 GB)"
                 kubespawner_override:
                   cpu_limit: 2
@@ -98,7 +98,7 @@ hubs:
                   mem_limit: 8G
                   mem_guarantee: 4G
                   node_selector:
-                    node.kubernetes.io/size: medium
+                    node.kubernetes.io/instance-type: n1-standard-32
               - display_name: "Large (12 GB - 16 GB)"
                 kubespawner_override:
                   cpu_limit: 4
@@ -106,7 +106,7 @@ hubs:
                   mem_limit: 16G
                   mem_guarantee: 12G
                   node_selector:
-                    node.kubernetes.io/size: large
+                    node.kubernetes.io/instance-type: n1-highmem-16
               - display_name: "ML Image - Large (12 GB - 16 GB)"
                 description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
                 kubespawner_override:
@@ -116,7 +116,7 @@ hubs:
                   mem_limit: 16G
                   mem_guarantee: 12G
                   node_selector:
-                    node.kubernetes.io/size: ml_large
+                    node.kubernetes.io/instance-type: n1-highmem-16
             initContainers:
               # Need to explicitly fix ownership here, since EFS doesn't do anonuid
             - name: volume-mount-ownership-fix

--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -79,34 +79,41 @@ hubs:
               # The mem-guarantees are here so k8s doesn't schedule other pods
               # on these nodes. They need to be just under total allocatable
               # RAM on a node, not total node capacity
-              - display_name: "Small"
-                description: "~2 CPU, ~8G RAM"
+              - display_name: "Small (1 GB - 4 GB)"
+                default: true
                 kubespawner_override:
+                  cpu_limit: 2
+                  cpu_guarantee: 0.3
+                  mem_limit: 4G
+                  mem_guarantee: 1G
+                  node_selector:
+                    node.kubernetes.io/size: small
+              - display_name: "Medium (4 GB - 8 GB)"
+                kubespawner_override:
+                  cpu_limit: 2
+                  cpu_guarantee: 1
                   mem_limit: 8G
-                  mem_guarantee: 5.5G
+                  mem_guarantee: 4G
                   node_selector:
-                    node.kubernetes.io/instance-type: n1-standard-2
-              - display_name: "Medium"
-                description: "~8 CPU, ~32G RAM"
+                    node.kubernetes.io/size: medium
+              - display_name: "Large (12 GB - 16 GB)"
                 kubespawner_override:
-                  mem_limit: 32G
-                  mem_guarantee: 25G
+                  cpu_limit: 4
+                  cpu_guarantee: 1
+                  mem_limit: 16G
+                  mem_guarantee: 12G
                   node_selector:
-                    node.kubernetes.io/instance-type: n1-standard-8
-              - display_name: "Large"
-                description: "~16 CPU, ~64G RAM"
+                    node.kubernetes.io/size: large
+              - display_name: "ML Image - Large (12 GB - 16 GB)"
+                description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
                 kubespawner_override:
-                  mem_limit: 64G
-                  mem_guarantee: 55G
+                  image: "pangeo/ml-notebook:master"
+                  cpu_limit: 2
+                  cpu_guarantee: 1
+                  mem_limit: 16G
+                  mem_guarantee: 12G
                   node_selector:
-                    node.kubernetes.io/instance-type: n1-standard-16
-              - display_name: "Very Large"
-                description: "~32 CPU, ~128G RAM"
-                kubespawner_override:
-                  mem_limit: 128G
-                  mem_guarantee: 115G
-                  node_selector:
-                    node.kubernetes.io/instance-type: n1-standard-32
+                    node.kubernetes.io/size: ml_large
             initContainers:
               # Need to explicitly fix ownership here, since EFS doesn't do anonuid
             - name: volume-mount-ownership-fix

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -10,31 +10,31 @@ enable_network_policy    = true
 # Some hubs want a storage bucket, so we need to have config connector enabled
 config_connector_enabled = true
 
-
+# Setup nodepools
 notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
     machine_type : "n1-standard-2",
-    labels: {}
+    labels: {"size": "small"}
   },
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-8",
-    labels: {}
+    machine_type : "n1-standard-2",
+    labels: {"size": "medium"}
   },
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-16",
-    labels: {}
+    machine_type : "n1-highmem-4",
+    labels: {"size": "large"}
   },
-  "very-large" : {
+  "ml_large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-32",
-    labels: {}
+    machine_type : "n1-highmem-4",
+    labels: {"size": "ml_large"}
   },
 }
 

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -15,26 +15,17 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-2",
-    labels: {"size": "small"}
+    labels: {}
   },
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-2",
-    labels: {"size": "medium"}
+    labels: {}
   },
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-4",
-    labels: {"size": "large"}
-  },
-  "ml_large" : {
-    min : 0,
-    max : 100,
-    machine_type : "n1-highmem-4",
-    labels: {"size": "ml_large"}
+    labels: {}
   },
 }
 

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -10,24 +10,30 @@ enable_network_policy    = true
 # Some hubs want a storage bucket, so we need to have config connector enabled
 config_connector_enabled = true
 
-# Setup nodepools
+
 notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-16",
+    machine_type : "n1-standard-2",
     labels: {}
   },
   "medium" : {
     min : 0,
     max : 100,
-    machine_type : "n1-standard-32",
+    machine_type : "n1-standard-8",
     labels: {}
   },
   "large" : {
     min : 0,
     max : 100,
-    machine_type : "n1-highmem-16",
+    machine_type : "n1-standard-16",
+    labels: {}
+  },
+  "very-large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-32",
     labels: {}
   },
 }

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -15,16 +15,19 @@ notebook_nodes = {
   "small" : {
     min : 0,
     max : 100,
+    machine_type : "n1-standard-16",
     labels: {}
   },
   "medium" : {
     min : 0,
     max : 100,
+    machine_type : "n1-standard-32",
     labels: {}
   },
   "large" : {
     min : 0,
     max : 100,
+    machine_type : "n1-highmem-16",
     labels: {}
   },
 }


### PR DESCRIPTION
### Summary

This PR brings the list of available profiles available on the Pangeo hub in line with what is currently being offered here: https://github.com/pangeo-data/pangeo-cloud-federation/blob/d051d1829aeb303d321dd483450146891f67a93c/deployments/gcp-uscentral1b/config/common.yaml#L76-L105

**Note:** `node_selector` has been removed as we are trialling node auto-provisioning on this cluster c.f. #670 

fixes #661 