### PR TITLE
Add config for a prod Pangeo hub

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -130,3 +130,9 @@ hubs:
               memory:
                 request: 1G
                 limit: 2G
+  - name: prod
+    domain: prod.pangeo.2i2c.cloud
+    template: daskhub
+    auth0:
+      connection: github
+    config: *stagingConfig


### PR DESCRIPTION
This PR configures a prod version of the Pangeo hub. It has already been deployed and HTTPS/DNS A records setup

fixes #652