### PR TITLE
Revert auto-provisioning on Pangeo cluster

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -89,18 +89,24 @@ hubs:
                   cpu_guarantee: 0.3
                   mem_limit: 4G
                   mem_guarantee: 1G
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-standard-4
               - display_name: "Medium (4 GB - 8 GB)"
                 kubespawner_override:
                   cpu_limit: 2
                   cpu_guarantee: 1
                   mem_limit: 8G
                   mem_guarantee: 4G
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-standard-8
               - display_name: "Large (12 GB - 16 GB)"
                 kubespawner_override:
                   cpu_limit: 4
                   cpu_guarantee: 1
                   mem_limit: 16G
                   mem_guarantee: 12G
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-standard-16
               - display_name: "ML Image - Large (12 GB - 16 GB)"
                 description: "https://github.com/pangeo-data/pangeo-docker-images/tree/master/ml-notebook"
                 kubespawner_override:
@@ -109,6 +115,8 @@ hubs:
                   cpu_guarantee: 1
                   mem_limit: 16G
                   mem_guarantee: 12G
+                  node_selector:
+                    node.kubernetes.io/instance-type: n1-standard-16
             initContainers:
               # Need to explicitly fix ownership here, since EFS doesn't do anonuid
             - name: volume-mount-ownership-fix

--- a/terraform/gcp/projects/pangeo-hubs.tfvars
+++ b/terraform/gcp/projects/pangeo-hubs.tfvars
@@ -12,9 +12,28 @@ config_connector_enabled = true
 # Setup a filestore for in-cluster NFS
 enable_filestore = true
 
-# Enable node auto-provisioning
-enable_node_autoprovisioning = true
-
 user_buckets = [
   "pangeo-scratch"
 ]
+
+# Setup notebook node pools
+notebook_nodes = {
+  "small" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-4",
+    labels: {}
+  },
+  "medium" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-8",
+    labels: {}
+  },
+  "large" : {
+    min : 0,
+    max : 100,
+    machine_type : "n1-standard-16",
+    labels: {}
+  },
+}


### PR DESCRIPTION
Let's revert node auto-provisioning on the Pangeo cluster until #677 is resolved.

Output of terraform plan:

```
Terraform will perform the following actions:

  # google_container_cluster.cluster will be updated in-place
  ~ resource "google_container_cluster" "cluster" {
        id                          = "projects/pangeo-integration-te-3eea/locations/us-central1-b/clusters/pangeo-hubs-cluster"
        name                        = "pangeo-hubs-cluster"
        # (28 unchanged attributes hidden)


      ~ cluster_autoscaling {
          ~ enabled             = true -> false
            # (1 unchanged attribute hidden)


          - resource_limits {
              - maximum       = 5200 -> null
              - minimum       = 1 -> null
              - resource_type = "memory" -> null
            }
          - resource_limits {
              - maximum       = 1000 -> null
              - minimum       = 1 -> null
              - resource_type = "cpu" -> null
            }
            # (1 unchanged block hidden)
        }













        # (14 unchanged blocks hidden)
    }

  # google_container_node_pool.dask_worker["large"] will be created
  + resource "google_container_node_pool" "dask_worker" {
      + cluster             = "pangeo-hubs-cluster"
      + id                  = (known after apply)
      + initial_node_count  = 0
      + instance_group_urls = (known after apply)
      + location            = "us-central1-b"
      + max_pods_per_node   = (known after apply)
      + name                = "dask-large"
      + name_prefix         = (known after apply)
      + node_count          = (known after apply)
      + node_locations      = (known after apply)
      + operation           = (known after apply)
      + project             = "pangeo-integration-te-3eea"
      + version             = (known after apply)

      + autoscaling {
          + max_node_count = 100
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-ssd"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "k8s.dask.org/node-purpose" = "worker"
            }
          + local_ssd_count   = (known after apply)
          + machine_type      = "n1-standard-16"
          + metadata          = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = true
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "k8s.dask.org_dedicated"
                  + value  = "worker"
                },
            ]

          + shielded_instance_config {
              + enable_integrity_monitoring = (known after apply)
              + enable_secure_boot          = (known after apply)
            }

          + workload_metadata_config {
              + node_metadata = "GKE_METADATA_SERVER"
            }
        }

      + upgrade_settings {
          + max_surge       = (known after apply)
          + max_unavailable = (known after apply)
        }
    }

  # google_container_node_pool.dask_worker["medium"] will be created
  + resource "google_container_node_pool" "dask_worker" {
      + cluster             = "pangeo-hubs-cluster"
      + id                  = (known after apply)
      + initial_node_count  = 0
      + instance_group_urls = (known after apply)
      + location            = "us-central1-b"
      + max_pods_per_node   = (known after apply)
      + name                = "dask-medium"
      + name_prefix         = (known after apply)
      + node_count          = (known after apply)
      + node_locations      = (known after apply)
      + operation           = (known after apply)
      + project             = "pangeo-integration-te-3eea"
      + version             = (known after apply)

      + autoscaling {
          + max_node_count = 100
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-ssd"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "k8s.dask.org/node-purpose" = "worker"
            }
          + local_ssd_count   = (known after apply)
          + machine_type      = "n1-standard-8"
          + metadata          = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = true
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "k8s.dask.org_dedicated"
                  + value  = "worker"
                },
            ]

          + shielded_instance_config {
              + enable_integrity_monitoring = (known after apply)
              + enable_secure_boot          = (known after apply)
            }

          + workload_metadata_config {
              + node_metadata = "GKE_METADATA_SERVER"
            }
        }

      + upgrade_settings {
          + max_surge       = (known after apply)
          + max_unavailable = (known after apply)
        }
    }

  # google_container_node_pool.dask_worker["small"] will be created
  + resource "google_container_node_pool" "dask_worker" {
      + cluster             = "pangeo-hubs-cluster"
      + id                  = (known after apply)
      + initial_node_count  = 0
      + instance_group_urls = (known after apply)
      + location            = "us-central1-b"
      + max_pods_per_node   = (known after apply)
      + name                = "dask-small"
      + name_prefix         = (known after apply)
      + node_count          = (known after apply)
      + node_locations      = (known after apply)
      + operation           = (known after apply)
      + project             = "pangeo-integration-te-3eea"
      + version             = (known after apply)

      + autoscaling {
          + max_node_count = 100
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = "pd-ssd"
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "k8s.dask.org/node-purpose" = "worker"
            }
          + local_ssd_count   = (known after apply)
          + machine_type      = "n1-standard-4"
          + metadata          = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = true
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "k8s.dask.org_dedicated"
                  + value  = "worker"
                },
            ]

          + shielded_instance_config {
              + enable_integrity_monitoring = (known after apply)
              + enable_secure_boot          = (known after apply)
            }

          + workload_metadata_config {
              + node_metadata = "GKE_METADATA_SERVER"
            }
        }

      + upgrade_settings {
          + max_surge       = (known after apply)
          + max_unavailable = (known after apply)
        }
    }

  # google_container_node_pool.notebook["large"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster             = "pangeo-hubs-cluster"
      + id                  = (known after apply)
      + initial_node_count  = 0
      + instance_group_urls = (known after apply)
      + location            = "us-central1-b"
      + max_pods_per_node   = (known after apply)
      + name                = "nb-large"
      + name_prefix         = (known after apply)
      + node_count          = (known after apply)
      + node_locations      = (known after apply)
      + operation           = (known after apply)
      + project             = "pangeo-integration-te-3eea"
      + version             = (known after apply)

      + autoscaling {
          + max_node_count = 100
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = (known after apply)
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + machine_type      = "n1-standard-16"
          + metadata          = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + shielded_instance_config {
              + enable_integrity_monitoring = (known after apply)
              + enable_secure_boot          = (known after apply)
            }

          + workload_metadata_config {
              + node_metadata = "GKE_METADATA_SERVER"
            }
        }

      + upgrade_settings {
          + max_surge       = (known after apply)
          + max_unavailable = (known after apply)
        }
    }

  # google_container_node_pool.notebook["medium"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster             = "pangeo-hubs-cluster"
      + id                  = (known after apply)
      + initial_node_count  = 0
      + instance_group_urls = (known after apply)
      + location            = "us-central1-b"
      + max_pods_per_node   = (known after apply)
      + name                = "nb-medium"
      + name_prefix         = (known after apply)
      + node_count          = (known after apply)
      + node_locations      = (known after apply)
      + operation           = (known after apply)
      + project             = "pangeo-integration-te-3eea"
      + version             = (known after apply)

      + autoscaling {
          + max_node_count = 100
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = (known after apply)
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + machine_type      = "n1-standard-8"
          + metadata          = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + shielded_instance_config {
              + enable_integrity_monitoring = (known after apply)
              + enable_secure_boot          = (known after apply)
            }

          + workload_metadata_config {
              + node_metadata = "GKE_METADATA_SERVER"
            }
        }

      + upgrade_settings {
          + max_surge       = (known after apply)
          + max_unavailable = (known after apply)
        }
    }

  # google_container_node_pool.notebook["small"] will be created
  + resource "google_container_node_pool" "notebook" {
      + cluster             = "pangeo-hubs-cluster"
      + id                  = (known after apply)
      + initial_node_count  = 0
      + instance_group_urls = (known after apply)
      + location            = "us-central1-b"
      + max_pods_per_node   = (known after apply)
      + name                = "nb-small"
      + name_prefix         = (known after apply)
      + node_count          = (known after apply)
      + node_locations      = (known after apply)
      + operation           = (known after apply)
      + project             = "pangeo-integration-te-3eea"
      + version             = (known after apply)

      + autoscaling {
          + max_node_count = 100
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = false
        }

      + node_config {
          + disk_size_gb      = (known after apply)
          + disk_type         = (known after apply)
          + guest_accelerator = (known after apply)
          + image_type        = (known after apply)
          + labels            = {
              + "hub.jupyter.org/node-purpose" = "user"
              + "k8s.dask.org/node-purpose"    = "scheduler"
            }
          + local_ssd_count   = (known after apply)
          + machine_type      = "n1-standard-4"
          + metadata          = (known after apply)
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
          + preemptible       = false
          + service_account   = "pangeo-hubs-cluster-sa@pangeo-integration-te-3eea.iam.gserviceaccount.com"
          + tags              = []
          + taint             = [
              + {
                  + effect = "NO_SCHEDULE"
                  + key    = "hub.jupyter.org_dedicated"
                  + value  = "user"
                },
            ]

          + shielded_instance_config {
              + enable_integrity_monitoring = (known after apply)
              + enable_secure_boot          = (known after apply)
            }

          + workload_metadata_config {
              + node_metadata = "GKE_METADATA_SERVER"
            }
        }

      + upgrade_settings {
          + max_surge       = (known after apply)
          + max_unavailable = (known after apply)
        }
    }

Plan: 6 to add, 1 to change, 0 to destroy.
```