### PR TITLE
Update URL for Pangeo prod hub

### DIFF
--- a/config/hubs/pangeo-hubs.cluster.yaml
+++ b/config/hubs/pangeo-hubs.cluster.yaml
@@ -139,7 +139,7 @@ hubs:
                 request: 1G
                 limit: 2G
   - name: prod
-    domain: prod.pangeo.2i2c.cloud
+    domain: pangeo.2i2c.cloud
     template: daskhub
     auth0:
       connection: github


### PR DESCRIPTION
Small PR that updates the URL of the Pangeo prod hub. I deployed this last night but forgot to open a PR.