### PR TITLE
Tweak CI so kops setup step only runs for AWS hubs

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -21,18 +21,26 @@ jobs:
       # Don't stop other deployments if one fails
       fail-fast: false
       matrix:
-        cluster_name:
+        include:
           # To enable auto-deployments for other clusters,
           # add its name to the list
-          - 2i2c
-          - cloudbank
-          - carbonplan
-          - farallon
+          - cluster_name: 2i2c
+            provider: gcp
+          - cluster_name: cloudbank
+            provider: gcp
+          - cluster_name: carbonplan
+            provider: aws
+          - cluster_name: farallon
+            provider: aws
           # Uncomment openscapes once a deployer user is created in openscapes AWS land
-          # - openscapes
-          - meom-ige
-          - pangeo-181919
-          - pangeo-hubs
+          # - cluster_name: openscapes
+          #   provider: aws
+          - cluster_name: meom-ige
+            provider: gcp
+          - cluster_name: pangeo-181919
+            provider: gcp
+          - cluster_name: pangeo-hubs
+            provider: gcp
 
     steps:
       - name: Checkout repo
@@ -87,7 +95,8 @@ jobs:
       - name: Setup kops
         if: |
           (steps.base_files.outputs.files == 'true') ||
-          (steps.config_files.outputs.hub_config == 'true')
+          (steps.config_files.outputs.hub_config == 'true') &&
+          (${{ matrix.provider }} == 'aws')
         run: |
           curl -Lo kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64
           chmod +x kops

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           # To enable auto-deployments for other clusters,
-          # add its name to the list
+          # add its name and provider to the list
           - cluster_name: 2i2c
             provider: gcp
           - cluster_name: cloudbank


### PR DESCRIPTION
Merging #673 introduced a bug to do with curl when installing kops manually. This is breaking CI for all hubs, but should only affect hubs deployed on AWS not GCP. This PR adds in some provider information into the matrix job and updates the condition on the kops install step to only run when the provider is AWS.