### PR TITLE
Fix bug caused by typo in deploy-hubs workflow file

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -96,7 +96,7 @@ jobs:
         if: |
           (steps.base_files.outputs.files == 'true') ||
           (steps.config_files.outputs.hub_config == 'true') &&
-          (${{ matrix.provider }} == 'aws')
+          (matrix.provider == 'aws')
         run: |
           curl -Lo kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64
           chmod +x kops


### PR DESCRIPTION
My bad! Variables don't need the `${{ ... }}` notation in `if` blocks