### PR TITLE
Revert to obscuring output from pytest

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -473,15 +473,20 @@ class Hub:
 
                 hub_url = f'https://{self.spec["domain"]}'
 
+                # On failure, pytest prints out params to the test that failed.
+                # This can contain sensitive info - so we hide stderr
+                # FIXME: Don't use pytest - just call a function instead
                 print("Running hub health check...")
-                exit_code = pytest.main([
-                    "-q",
-                    "deployer/tests",
-                    "--hub-url", hub_url,
-                    "--api-token", service_api_token,
-                    "--hub-type", self.spec['template'],
-                    "--tb=short"
-                ])
-
+                with open(os.devnull, 'w') as dn, redirect_stderr(dn), redirect_stdout(dn):
+                    exit_code = pytest.main([
+                        "-q",
+                        "deployer/tests",
+                        "--hub-url", hub_url,
+                        "--api-token", service_api_token,
+                        "--hub-type", self.spec['template']
+                    ])
                 if exit_code != 0:
+                    print("Health check failed!", file=sys.stderr)
                     sys.exit(exit_code)
+                else:
+                    print("Health check succeeded!")


### PR DESCRIPTION
Pytest is continuing to leak tokens in URLs when tests fail. This PR reverts to the state where we redirect pytest's output to /dev/null. We should iterate on this and move away from pytest completely.

P.S. there's a weird double commit here because I accidentally committed to master on my fork, then did a cherry-pick but I had untracked files so git complained and made me do `git commit --allow-empty`. Why does everything break when you're trying to be efficient?