### PR TITLE
[BUGFIX] Create JupyterHub key in generated config

### DIFF
--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -348,7 +348,7 @@ class Hub:
             # NOTE: Some dictionary merging might make these lines prettier/more readable.
             # Since Auth0 is enabled, we set the authenticator_class to the CustomOAuthenticator we define in the basehub chart
             # https://github.com/2i2c-org/pilot-hubs/blob/master/hub-templates/basehub/values.yaml#L303-L318
-            generated_config['jupyterhub']['hub']['config']['JupyterHub']['authenticator_class'] = 'CustomOAuthenticator'
+            generated_config['jupyterhub']['hub']['config']['JupyterHub'] = {'authenticator_class': 'CustomOAuthenticator'}
             generated_config['jupyterhub']['hub']['config']['Auth0OAuthenticator'] = auth_provider.get_client_creds(client, self.spec['auth0']['connection'])
 
         return self.apply_hub_template_fixes(generated_config, secret_key)

--- a/deployer/hub.py
+++ b/deployer/hub.py
@@ -348,7 +348,7 @@ class Hub:
             # NOTE: Some dictionary merging might make these lines prettier/more readable.
             # Since Auth0 is enabled, we set the authenticator_class to the CustomOAuthenticator we define in the basehub chart
             # https://github.com/2i2c-org/pilot-hubs/blob/master/hub-templates/basehub/values.yaml#L303-L318
-            generated_config['jupyterhub']['hub']['config']['JupyterHub'] = {'authenticator_class': 'CustomOAuthenticator'}
+            generated_config['jupyterhub']['hub']['config']['JupyterHub'] = {'authenticator_class': 'oauthenticator.auth0.Auth0OAuthenticator'}
             generated_config['jupyterhub']['hub']['config']['Auth0OAuthenticator'] = auth_provider.get_client_creds(client, self.spec['auth0']['connection'])
 
         return self.apply_hub_template_fixes(generated_config, secret_key)


### PR DESCRIPTION
Merging #726 failed in non-Auth0 cases due to a Python error where the `JupyterHub` key in the generated config didn't exist. This PR fixes that issue by tweaking the Python code so the key is created.

Also, setting `authenticator_class` to `CustomOAuthenticator` was the wrong move as the `extra_config` is loaded into the hub last and this caused a bad config error (see below comment). Reverting back to the Auth0 class resulted in a successful deploy to 2i2c-staging hub.