### PR TITLE
Dynamically set authenticator_class

### DIFF
--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -298,6 +298,7 @@ jupyterhub:
         c.JupyterHub.spawner_class = CustomSpawner
 
       06-custom-authenticator: |
+        from z2jh import get_config
         from oauthenticator.auth0 import Auth0OAuthenticator
 
         class CustomOAuthenticator(Auth0OAuthenticator):
@@ -313,6 +314,11 @@ jupyterhub:
               # needed. This method is simpler
               resp['name'] = resp['name'].split('|')[-1]
             return resp
+
+        authenticator_class = get_config('hub.config.JupyterHub.authenticator_class')
+
+        if "Auth0" in authenticator_class:
+          c.JupyterHub.authenticator_class = CustomOAuthenticator
 
       07-cloud-storage-bucket: |
         from z2jh import get_config


### PR DESCRIPTION
This resets the authenticator_class to `CustomOAuthenticator` if the `Auth0`
class has originally been instantiated. This allows us to continue
supporting ORCiD login.

This is a short-term fix that addresses concerns raised in https://github.com/2i2c-org/pilot-hubs/discussions/731