### PR TITLE
Remove singleuser network policies from basehub and daskhub charts

### DIFF
--- a/config/hubs/2i2c.cluster.yaml
+++ b/config/hubs/2i2c.cluster.yaml
@@ -52,6 +52,7 @@ hubs:
                 - colliand@gmail.com
                 - choldgraf@gmail.com
                 - georgiana.dolocan@gmail.com
+                - sgibson@2i2c.org
               admin_users: *staging_users
   - name: dask-staging
     domain: dask-staging.pilot.2i2c.cloud

--- a/hub-templates/basehub/values.yaml
+++ b/hub-templates/basehub/values.yaml
@@ -150,26 +150,6 @@ jupyterhub:
     memory:
       guarantee: 256M
       limit: 1G
-    networkPolicy:
-      # In clusters with NetworkPolicy enabled, do not
-      # allow outbound internet access that's not DNS, HTTP or HTTPS
-      # We can override this on a case to case basis where
-      # required.
-      enabled: true
-      egress:
-        # FIXME: Either remove UDP for port 53 as this is now default in z2jh
-        # OR also explicitly allow TCP on port 53 as that will prevent some
-        # DNS lookups from failing over UDP because, e.g., the DNS has many IPs
-        # for a certain domain name and fallback to TCP
-        - ports:
-            - port: 53
-              protocol: UDP
-        - ports:
-            - port: 80
-              protocol: TCP
-        - ports:
-            - port: 443
-              protocol: TCP
   hub:
     extraFiles:
       configurator-schema-default:

--- a/hub-templates/daskhub/values.yaml
+++ b/hub-templates/daskhub/values.yaml
@@ -17,31 +17,6 @@ basehub:
       defaultUrl: /lab
       extraLabels:
          hub.jupyter.org/network-access-proxy-http: "true"
-
-      networkPolicy:
-        egress:
-          # Needed to talk to metadata server.
-          # see https://github.com/2i2c-org/pilot-hubs/issues/280
-          - to:
-              - ipBlock:
-                  cidr: 127.0.0.1/32
-            ports:
-              - port: 988
-                protocol: TCP
-          # Needed for talking to the proxy pod
-          - ports:
-              - port: 8000
-                protocol: TCP
-          - ports:
-              - port: 80
-                protocol: TCP
-          - ports:
-              - port: 443
-                protocol: TCP
-          # Enable outgoing ssh by default on these hubs
-          - ports:
-              - port: 22
-                protocol: TCP
       cloudMetadata:
         # Don't block access to AWS cloud metadata
         # If we don't, our users can't access S3 buckets / other AWS services


### PR DESCRIPTION
This is a test PR I deployed locally to 2i2c-staging to see if the user servers have access to prometheus (which we don't want!) without these policies