### PR TITLE
Add missing dependencies to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,5 @@ pytest
 pytest-asyncio
 requests
 beautifulsoup4
+auth0-python
+yarl


### PR DESCRIPTION
It seems like I needed to install these to run `python3 deployer deploy jmte --skip-hub-health-test`. Does it make sense to add these here then?